### PR TITLE
add multi-ingress template

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.38
+version: 0.2.39
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.2.38](https://img.shields.io/badge/Version-0.2.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.39](https://img.shields.io/badge/Version-0.2.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -43,7 +43,8 @@ A Helm chart for Kubernetes
 | imagePullSecrets | list | `[]` |  |
 | ingress | bool | `{"enabled":false}` | If true, Creats Ingress DNS name to expose the service publicly |
 | livenessProbe | object | `{}` |  |
-| nameOverride | string | `"{{ .Release.Name }}"` |  |
+| multiIngress | bool | `{"enabled":false}` | If true, Creats Multible Ingresses DNS name to expose the service publicly |
+| nameOverride | string | `"test"` |  |
 | nodeSelectorLabels | object | `{}` | Provide node groups selector |
 | nodeTolerations | list | `[]` | Node Tolerations. Tolerations allow the scheduler to schedule pods with matching taints |
 | podAffinity | object | `{}` | Pod affinity rule. Default affinity rule is set to make sure pods are not deployed on the same node |

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -43,8 +43,8 @@ A Helm chart for Kubernetes
 | imagePullSecrets | list | `[]` |  |
 | ingress | bool | `{"enabled":false}` | If true, Creats Ingress DNS name to expose the service publicly |
 | livenessProbe | object | `{}` |  |
-| nameOverride | string | `"{{ .Release.Name }}"` | |
 | multiIngress | bool | `{"enabled":false}` | If true, Creats Multible Ingresses DNS name to expose the service publicly |
+| nameOverride | string | `"{{ .Release.Name }}"` |  |
 | nodeSelectorLabels | object | `{}` | Provide node groups selector |
 | nodeTolerations | list | `[]` | Node Tolerations. Tolerations allow the scheduler to schedule pods with matching taints |
 | podAffinity | object | `{}` | Pod affinity rule. Default affinity rule is set to make sure pods are not deployed on the same node |

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -44,7 +44,7 @@ A Helm chart for Kubernetes
 | ingress | bool | `{"enabled":false}` | If true, Creats Ingress DNS name to expose the service publicly |
 | livenessProbe | object | `{}` |  |
 | multiIngress | bool | `{"enabled":false}` | If true, Creats Multible Ingresses DNS name to expose the service publicly |
-| nameOverride | string | `"{{ .Release.Name }}"` |  |
+| nameOverride | string | `""` |  |
 | nodeSelectorLabels | object | `{}` | Provide node groups selector |
 | nodeTolerations | list | `[]` | Node Tolerations. Tolerations allow the scheduler to schedule pods with matching taints |
 | podAffinity | object | `{}` | Pod affinity rule. Default affinity rule is set to make sure pods are not deployed on the same node |

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -43,8 +43,8 @@ A Helm chart for Kubernetes
 | imagePullSecrets | list | `[]` |  |
 | ingress | bool | `{"enabled":false}` | If true, Creats Ingress DNS name to expose the service publicly |
 | livenessProbe | object | `{}` |  |
+| nameOverride | string | `"{{ .Release.Name }}"` | |
 | multiIngress | bool | `{"enabled":false}` | If true, Creats Multible Ingresses DNS name to expose the service publicly |
-| nameOverride | string | `"test"` |  |
 | nodeSelectorLabels | object | `{}` | Provide node groups selector |
 | nodeTolerations | list | `[]` | Node Tolerations. Tolerations allow the scheduler to schedule pods with matching taints |
 | podAffinity | object | `{}` | Pod affinity rule. Default affinity rule is set to make sure pods are not deployed on the same node |

--- a/charts/service/templates/ingress-multi.yaml
+++ b/charts/service/templates/ingress-multi.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.multiIngress.enabled -}}
+{{- $fullName := include "service.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{ range .Values.multiIngress.ingress }}
+{{- if and .className (not (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .name }}-ingress
+  labels:
+  {{- include "service.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .className }}
+  {{- end }}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+---          
+{{ end }}
+{{ end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
 
 imagePullSecrets: []
-nameOverride: "{{ .Release.Name }}"
+nameOverride: ""
 fullnameOverride: ""
 # -- Provide node groups selector
 nodeSelectorLabels: {}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -48,7 +48,7 @@ extraService:
   enabled: false
   port: 9113
   targetPort: 9113
-  type: ClusterIP 
+  type: ClusterIP
   portName: extraport
 
 
@@ -115,7 +115,7 @@ argorollouts:
   enabled: false
   steps:
   - setWeight: 20
-  - pause:  
+  - pause:
       duration: "1m"
   - setWeight: 60
   - pause: {}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -56,6 +56,10 @@ extraService:
 ingress:
   enabled: false
 
+# -- (bool) If true, Creats Multible Ingresses DNS name to expose the service publicly
+multiIngress:
+  enabled: false
+
 # We should always specify how much of each resource a container needs.
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 resources: {}


### PR DESCRIPTION
## What this PR does / why we need it:

Adding helm template to create multi-able ingresses for one release, it will help us to create a separate ingress for VPN white-listed endpoints 

## Checklist

- [ ] Meaningful PR title
- [ ] Updated README
- [ ] Github actions are passing
- [ ] I have added the Jira task
