### PR TITLE
fix awk in pre-release check for . dir

### DIFF
--- a/scripts/helm-release-chart.sh
+++ b/scripts/helm-release-chart.sh
@@ -8,7 +8,7 @@ function release-helm-chart {
     exit 1
   fi
   echo -e "\nGenerating Helm Chart package for new version."
-  changedDir=`git diff --name-only HEAD~1 | awk -F "/*[^/]*/*$" '{ print ($1 == " " ? "." : $1); }' | sort | uniq | head -n1`
+  changedDir=`git diff --name-only HEAD~1 | awk -F "/*[^/]*/*$" '{ if ($1 != "") print $1; else print "." }' | sort | uniq | head -n1`
   echo "Packaging $changedDir..."
   rm -rf $changedDir/charts/*.tgz
   helm package -u $changedDir


### PR DESCRIPTION
root dir changes were being printed as blank line instead of `.`:

```
❯ git diff --name-only HEAD~1
README.md
charts/service/Chart.yaml
charts/service/README.md
charts/service/templates/destinationRule.yaml
charts/service/values.yaml
```

```
❯ git diff --name-only HEAD~1 | awk -F "/*[^/]*/*$" '{ print ($1 == " " ? "." : $1); }'

charts/service
charts/service
charts/service/templates
charts/service
```
this caused last helm release to fail: https://github.com/Breadfast/helm-chart/actions/runs/11912317387/job/33195643541