### PR TITLE
feat(charts/service): Remove replicas from Argo Rollouts template when hpa is enabled

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.47
+version: 0.2.48
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.2.47](https://img.shields.io/badge/Version-0.2.47-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.48](https://img.shields.io/badge/Version-0.2.48-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/service/templates/argo-rollouts.yaml
+++ b/charts/service/templates/argo-rollouts.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   revisionHistoryLimit: 2
   strategy:
     canary:


### PR DESCRIPTION
# Changes :arrows_counterclockwise: 

- Removed replicas from Argo Rollouts template when HPA is enabled to avoid scaling conflicts between HPA and ArgoCD.
- This change is already implemented in the Kubernetes Deployment template.
- Renamed `argoo-rollouts.yaml` template to `argo-rollouts.yaml` .
