### PR TITLE
Add dynamicStableScale Argo

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.49
+version: 0.2.50
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.2.49](https://img.shields.io/badge/Version-0.2.49-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.50](https://img.shields.io/badge/Version-0.2.50-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -20,6 +20,7 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argorollouts.dynamicStableScale | bool | `false` |  |
 | argorollouts.enabled | bool | `false` |  |
 | argorollouts.steps[0].setWeight | int | `20` |  |
 | argorollouts.steps[1].pause.duration | string | `"1m"` |  |

--- a/charts/service/templates/argo-rollouts.yaml
+++ b/charts/service/templates/argo-rollouts.yaml
@@ -22,7 +22,7 @@ spec:
   revisionHistoryLimit: 2
   strategy:
     canary:
-      {{- if .Values.canary.dynamicStableScale.enabled }}
+      {{- if .Values.argorollouts.dynamicStableScale }}
       dynamicStableScale: true
       {{- end }}
       {{- if .Values.argorollouts.analysis }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -128,6 +128,7 @@ datadog:
 nodeTolerations: []
 
 argorollouts:
+  dynamicStableScale: false
   enabled: false
   steps:
   - setWeight: 20


### PR DESCRIPTION
## What this PR does / why we need it:

https://argo-rollouts.readthedocs.io/en/stable/features/canary/
Add dynamicStableScale to argorollout 
The ability to dynamically scale the stable ReplicaSet can be enabled by setting the canary.dynamicStableScale flag to true

## Checklist

- [ ] Meaningful PR title
- [ ] Updated README
- [ ] Github actions are passing
- [ ] I have added the Jira task
