### PR TITLE
feat: Added ArgoCD PreSync hook job to validate vault injected env variables

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.54
+version: 0.2.55
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.2.54](https://img.shields.io/badge/Version-0.2.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.55](https://img.shields.io/badge/Version-0.2.55-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -20,6 +20,7 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argoPreSyncValidator | object | `{"backoffLimit":1,"command":["php","-l","/vault/secrets/wp-config.php"],"enabled":false,"ttlSecondsAfterFinished":60}` | If true, create ArgoCD PreSync job to validate environment variables injected from Vault |
 | argorollouts.dynamicStableScale | bool | `true` |  |
 | argorollouts.enabled | bool | `false` |  |
 | argorollouts.steps[0].setWeight | int | `20` |  |

--- a/charts/service/templates/validate-job.yaml
+++ b/charts/service/templates/validate-job.yaml
@@ -1,0 +1,47 @@
+{{ if .Values.argoPreSyncValidator.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "service.fullname" . }}-validate-job
+  labels:
+  {{- include "service.labels" $ | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: {{ .Values.argoPreSyncValidator.backoffLimit | default 1 }}
+  ttlSecondsAfterFinished: {{ .Values.argoPreSyncValidator.ttlSecondsAfterFinished | default 300 }}
+  template:
+    metadata:
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.vaultAgent.enabled }}
+        {{- toYaml .Values.vaultAgent.annotations | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "service.labels" $ | nindent 8 }}
+    spec:
+      containers:
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: argocd-validator-job
+        command: {{ .Values.argoPreSyncValidator.command }}
+      {{- with $.Values.nodeSelectorLabels }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.vaultAgent.enabled }}
+      serviceAccountName: {{ .Values.vaultAgent.serviceAccount }}
+      {{- else }}
+      serviceAccountName: {{ include "service.serviceAccountName" . }}
+      {{- end }}
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 120
+      tolerations:
+      {{- if .Values.nodeTolerations }}
+        {{- toYaml .Values.nodeTolerations | nindent 8}}
+      {{- end }}
+{{ end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -168,3 +168,10 @@ goreplay:
   args: ["-input-raw", "any:80", "--output-file", "/traffic/requests-%Y-%m-%d-%H.log", "-verbose", "2", "--output-file-append"]
   gcpbucketName: "goreplay-non-prod"
   image: "us-central1-docker.pkg.dev/prj-n-floating-623c/apps/goreplay:latest"
+
+# -- If true, create ArgoCD PreSync job to validate environment variables injected from Vault
+argoPreSyncValidator:
+  enabled: false
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 60
+  command: ["php", "-l", "/vault/secrets/wp-config.php"]


### PR DESCRIPTION

## What this PR does / why we need it:

This PR should add option to create an ArgoCD PreSync hook job to validate environment variables injected by Vault in PHP (WordPress)-based apps. 

## Checklist

- [ ] Meaningful PR title
- [ ] Updated README
- [ ] Github actions are passing
- [ ] I have added the Jira task
