### PR TITLE
feat(service-chart): add configurable service annotations

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.60
+version: 0.2.61
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.2.60](https://img.shields.io/badge/Version-0.2.60-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.61](https://img.shields.io/badge/Version-0.2.61-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes.
 
@@ -93,6 +93,7 @@ Ingress resources are unchanged; you can use Ingress only, Gateway only, or both
 | resources | object | `{}` |  |
 | rollingStrategy | string | `"RollingUpdate"` | Specify deployment rolling strategy: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 | securityContext | object | `{}` |  |
+| service.annotations | object | `{}` | Additional annotations for the Kubernetes Service |
 | service.name | string | `"http"` | Service port name when single port service |
 | service.port | int | `80` | Kubernetes service port when single port service |
 | service.ports | list | `[]` | Used when the service container requires multiple ports. The port parameter will be ignored if this is set.    Example:       - name: http         port: 8069         targetPort: 8069       - name: websocket         port: 8072         targetPort: 8072       - name: xmlrpc         port: 8071         targetPort: 8071 |

--- a/charts/service/templates/service.yaml
+++ b/charts/service/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "service.fullname" . }}-service
   labels:
     {{- include "service.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -44,6 +44,8 @@ securityContext: {}
 service:
   # -- Service type, can be either `ClusterIP`, `NodePort`, `LoadBalancer` or `ExternalName`
   type: ClusterIP
+  # -- Additional annotations for the Kubernetes Service
+  annotations: {}
   # -- Service port name when single port service
   name: http
   # -- Kubernetes service port when single port service


### PR DESCRIPTION
## What this PR does / why we need it:

Enable adding annotations to the Kubernetes Service object created by the service helm chart that might be needed to extend the functionality of the Service Object like exposing it as a NEG (Network Endpoint Group) in the underlying GCP environment.

<!--- Describe your changes in detail -->

## Checklist

- [x] Meaningful PR title
- [x] Updated README
- [x] Github actions are passing
- [ ] I have added the Jira task
