### PR TITLE
feat(rudderstack): GKE Gateway API support for ingestion (0.2.0)

### DIFF
--- a/charts/rudderstack/Chart.yaml
+++ b/charts/rudderstack/Chart.yaml
@@ -17,7 +17,7 @@ description: |
 type: application
 
 # Chart version. Bump on every change to the chart/templates.
-version: 0.1.0
+version: 0.2.0
 
 # Deployed rudder-server / rudder-transformer application version (see values).
 appVersion: "1.74.1"

--- a/charts/rudderstack/README.md
+++ b/charts/rudderstack/README.md
@@ -1,6 +1,6 @@
 # rudderstack
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
 
 Breadfast self-hosted RudderStack (Segment-alternative) data plane.
 
@@ -51,6 +51,20 @@ chart carries placeholders only, never plaintext.
 | backend.processor | object | `{"affinity":{},"enableProcessor":true,"enableRouter":true,"metricsService":{"enabled":true,"name":"rudder-metrics"},"nodeSelector":{},"persistence":{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":true,"size":"20Gi"},"podAnnotations":{},"podLabels":{},"resources":{"limits":{"memory":"4096Mi"},"requests":{"cpu":"1","memory":"2048Mi"}},"terminationGracePeriodSeconds":300,"tolerations":[],"topologySpreadConstraints":[],"warehouseMode":"embedded","webPort":8086}` | ----------------------------------------------------------------------- |
 | backend.workspaceTokenKey | string | `"workspace_token"` | Vault key (under vault.path) for the workspace token -> CONFIG_BACKEND_TOKEN. |
 | commonLabels | object | `{}` | Labels applied to every resource in the chart. |
+| gateway.annotations | object | `{}` |  |
+| gateway.backendPolicy.enabled | bool | `false` |  |
+| gateway.enabled | bool | `false` |  |
+| gateway.gatewayName | string | `""` |  |
+| gateway.gatewayNamespace | string | `""` |  |
+| gateway.healthCheck.checkIntervalSec | int | `30` |  |
+| gateway.healthCheck.enabled | bool | `false` |  |
+| gateway.healthCheck.healthyThreshold | int | `1` |  |
+| gateway.healthCheck.path | string | `"/health"` |  |
+| gateway.healthCheck.port | string | `""` |  |
+| gateway.healthCheck.timeoutSec | int | `10` |  |
+| gateway.healthCheck.type | string | `"HTTP"` |  |
+| gateway.healthCheck.unhealthyThreshold | int | `5` |  |
+| gateway.hosts | list | `[]` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.storageClass | string | `""` | StorageClass for the processor's RUDDER_TMPDIR PVC ("" = cluster default). |
 | ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |

--- a/charts/rudderstack/templates/gcp-backend-policy.yaml
+++ b/charts/rudderstack/templates/gcp-backend-policy.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.gateway.enabled .Values.gateway.backendPolicy .Values.gateway.backendPolicy.enabled -}}
+{{- /*
+Optional GCPBackendPolicy for the ingestion gateway Service (Cloud Armor,
+backend timeout, logging). Disabled by default. Mirrors the 'service' chart.
+*/ -}}
+{{- $bp := .Values.gateway.backendPolicy -}}
+{{- $svc := $bp.serviceName | default (include "gateway.fullname" .) -}}
+{{- $iapEnabled := and $bp.iap $bp.iap.enabled -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: {{ include "gateway.fullname" . }}-backendpolicy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.gateway | quote }}
+spec:
+  default:
+    {{- if hasKey $bp "timeoutSec" }}
+    timeoutSec: {{ $bp.timeoutSec }}
+    {{- end }}
+    {{- if $iapEnabled }}
+    {{- with $bp.securityPolicy }}
+    securityPolicy: {{ . | quote }}
+    {{- end }}
+    iap:
+      {{- toYaml $bp.iap | nindent 6 }}
+    {{- else }}
+    securityPolicy: {{ required "gateway.backendPolicy.securityPolicy is required when gateway.backendPolicy.enabled is true" $bp.securityPolicy | quote }}
+    {{- end }}
+    {{- with $bp.logging }}
+    logging:
+      enabled: {{ .enabled }}
+      {{- if hasKey . "sampleRate" }}
+      sampleRate: {{ .sampleRate }}
+      {{- end }}
+    {{- end }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $svc }}
+{{- end }}

--- a/charts/rudderstack/templates/health-check-policy.yaml
+++ b/charts/rudderstack/templates/health-check-policy.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.gateway.enabled .Values.gateway.healthCheck.enabled -}}
+{{- /*
+GKE health check for the ingestion gateway Service behind the Gateway. Defaults
+to an HTTP check on the gateway web port (/health), matching the rudder-server
+gateway liveness surface.
+*/ -}}
+{{- $hc := .Values.gateway.healthCheck -}}
+{{- $svc := include "gateway.fullname" . -}}
+{{- $port := $hc.port | default .Values.backend.gateway.webPort -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ $svc }}-healthcheck
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.gateway | quote }}
+spec:
+  default:
+    checkIntervalSec: {{ $hc.checkIntervalSec | default 30 }}
+    timeoutSec: {{ $hc.timeoutSec | default 10 }}
+    healthyThreshold: {{ $hc.healthyThreshold | default 1 }}
+    unhealthyThreshold: {{ $hc.unhealthyThreshold | default 5 }}
+    config:
+      type: {{ $hc.type | default "HTTP" }}
+      {{- if eq ($hc.type | default "HTTP") "TCP" }}
+      tcpHealthCheck:
+        port: {{ $port }}
+      {{- else }}
+      httpHealthCheck:
+        port: {{ $port }}
+        requestPath: {{ $hc.path | default "/health" }}
+      {{- end }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $svc }}
+{{- end }}

--- a/charts/rudderstack/templates/httproute.yaml
+++ b/charts/rudderstack/templates/httproute.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.gateway.enabled .Values.gateway.hosts -}}
+{{- /*
+GKE Gateway API routing for the GATEWAY (ingestion) Service, mirroring the
+Breadfast 'service' chart. Attaches to a shared Gateway (e.g. breadfast-gateway
+in gateway-infra) and replaces the nginx Ingress. serviceName/servicePort default
+to this chart's ingestion gateway Service.
+*/ -}}
+{{- $fullName := include "rudderstack.fullname" . -}}
+{{- $defaultSvc := include "gateway.fullname" . -}}
+{{- $defaultPort := .Values.backend.gateway.service.port -}}
+{{- $ann := .Values.gateway.annotations | default dict -}}
+{{- range $hIdx, $h := .Values.gateway.hosts }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-httproute-%d" $fullName (int $hIdx) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "gateway.selectorLabels" $ | nindent 4 }}
+    {{- include "rudderstack.labels" $ | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $.Values.syncWaves.gateway | quote }}
+    {{- with $ann }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $.Values.gateway.gatewayName | required "gateway.gatewayName is required when gateway.enabled is true" }}
+      {{- with $.Values.gateway.gatewayNamespace }}
+      namespace: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ $h.host | quote }}
+  rules:
+    {{- range $h.paths }}
+    - matches:
+        - path:
+            type: {{ if eq (.pathType | default "Prefix") "Exact" }}Exact{{ else }}PathPrefix{{ end }}
+            value: {{ .path | quote }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .serviceName | default $defaultSvc }}
+          port: {{ .servicePort | default $defaultPort }}
+    {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/rudderstack/values.yaml
+++ b/charts/rudderstack/values.yaml
@@ -206,10 +206,13 @@ persistence:
   mountPath: /data/rudderstack
 
 # ===========================================================================
-# Ingress (gateway only - ingestion endpoint).
-# Generic defaults; the real hostname / TLS secret / cert-manager issuer are
-# set in the private overlay.
+# Ingestion entrypoint for the GATEWAY (ingestion) Service. Two mutually
+# exclusive options:
+#   1. ingress  (nginx)        - LEGACY, being deprecated.
+#   2. gateway  (GKE Gateway API) - preferred; mirrors the Breadfast 'service'
+#      chart. Enable one, disable the other.
 # ===========================================================================
+# --- Option 1: nginx Ingress (legacy) ---
 ingress:
   enabled: true
   tls: true
@@ -219,6 +222,40 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
   labels: {}
+
+# --- Option 2: GKE Gateway API (HTTPRoute + HealthCheckPolicy + GCPBackendPolicy) ---
+# Attaches the ingestion gateway Service to a shared Gateway (e.g.
+# breadfast-gateway / gateway-infra). serviceName/servicePort in hosts[].paths[]
+# default to this chart's ingestion gateway Service, so the overlay only needs
+# host + path. TLS is terminated at the Gateway; Cloudflare proxies the domain.
+gateway:
+  enabled: false
+  gatewayName: ""        # e.g. breadfast-gateway
+  gatewayNamespace: ""   # e.g. gateway-infra
+  annotations: {}
+  # hosts:
+  #   - host: events.example.com
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix       # or Exact
+  #         # serviceName/servicePort default to the ingestion gateway Service
+  hosts: []
+  # GCP LB health check for the backend NEG. HTTP /health on the gateway web port.
+  healthCheck:
+    enabled: false
+    type: HTTP             # HTTP or TCP
+    port: ""              # defaults to backend.gateway.webPort (8080)
+    path: /health
+    checkIntervalSec: 30
+    timeoutSec: 10
+    healthyThreshold: 1
+    unhealthyThreshold: 5
+  # Optional Cloud Armor / backend timeout / logging on the ingestion Service.
+  backendPolicy:
+    enabled: false
+    # securityPolicy: "<cloud-armor-policy>"
+    # timeoutSec: 3600
+    # logging: { enabled: true, sampleRate: 1.0 }
 
 # ===========================================================================
 # Transformer subchart (charts/transformer) - HA, gateway readiness depends on it.


### PR DESCRIPTION
## What
Adds **GKE Gateway API** support to the rudderstack chart so the data-plane ingestion endpoint can front through a shared Gateway (e.g. `breadfast-gateway` / `gateway-infra`) — mirroring the `service` chart — instead of the nginx Ingress (being deprecated).

New templates (opt-in via `gateway.enabled`, wave 2):
- `httproute.yaml` — `HTTPRoute` for the ingestion gateway Service; `serviceName`/`servicePort` default to the chart's ingestion Service.
- `health-check-policy.yaml` — GCP `HealthCheckPolicy` (HTTP `/health` on the gateway web port by default).
- `gcp-backend-policy.yaml` — optional Cloud Armor / timeout / logging (disabled by default).

Chart bumped **0.1.0 → 0.2.0**. nginx `ingress` retained for backward compatibility; `gateway` and `ingress` are mutually exclusive (enable one).

## Validation
- `helm lint` clean; renders with `gateway.enabled=true` produce a correct HTTPRoute (parentRef `breadfast-gateway/gateway-infra`, backendRef `rudderstack-gateway:80`) + HealthCheckPolicy (HTTP `:8080/health` targeting the ingestion Service), and **no Ingress** when `ingress.enabled=false`.
- Verified against the live prod Gateway: HTTP/HTTPS listeners, `allowedRoutes: All`, TLS cert `*.breadfast.com` (Cloudflare Origin) already covers `events.breadfast.com`.
- README regenerated with helm-docs; `Chart.lock` unchanged (transformer dep untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)