### PR TITLE
fix(ci): robust chart publishing (worktree; unblocks rudderstack 0.2.0)

### DIFF
--- a/scripts/helm-release-chart.sh
+++ b/scripts/helm-release-chart.sh
@@ -6,23 +6,28 @@ REPO_URL="https://breadfast.github.io/helm-chart"
 
 # Packages the charts under charts/* and publishes the .tgz + a merged
 # index.yaml to the gh-pages branch (the Breadfast public Helm registry).
-# Previously this only handled charts/service; it now loops over all charts so
-# new charts (e.g. charts/rudderstack) are published without further edits.
+# Loops over all charts so new charts (e.g. charts/rudderstack) publish without
+# further edits.
 #
-# GUARD: --merge would silently overwrite a published version in place. So:
-#   - if a chart CHANGED in this commit but its version is already published,
-#     FAIL (someone forgot to bump the version);
-#   - if a chart's version is already published and it did NOT change, SKIP it
-#     (leave the published artifact untouched);
+# GUARD (prevents --merge from silently overwriting a published version):
+#   - chart CHANGED in this commit but its version is already published -> FAIL;
+#   - version already published and unchanged -> SKIP;
 #   - otherwise package it (new/bumped version).
+#
+# Publishing happens in a SEPARATE git worktree for gh-pages so the packaging
+# artifacts in the main tree (vendored dependency .tgz created by `helm
+# dependency update`, Chart.lock touch-ups) never collide with a branch switch.
 function release-helm-charts {
   git fetch origin gh-pages --depth=1 || true
 
   local changedFiles
   changedFiles="$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)"
 
+  local pkgDir
+  pkgDir="$(mktemp -d)"
+
   echo -e "\nSelecting charts to package ..."
-  local toPackage=()
+  local packaged=0
   for chartDir in charts/*/; do
     [ -f "${chartDir}Chart.yaml" ] || continue
     local name version
@@ -38,27 +43,36 @@ function release-helm-charts {
       echo "Skipping ${name}-${version} (already published, unchanged)."
       continue
     fi
-    toPackage+=("${chartDir}")
+
+    echo "Packaging ${name}-${version} ..."
+    helm dependency update "${chartDir}" >/dev/null 2>&1 || true
+    helm package "${chartDir}" -d "${pkgDir}"   # chart package lands in pkgDir
+    packaged=$((packaged + 1))
   done
 
-  if [ "${#toPackage[@]}" -eq 0 ]; then
-    echo "No new chart versions to publish."; return 0
+  if [ "${packaged}" -eq 0 ]; then
+    echo "No new chart versions to publish."; rm -rf "${pkgDir}"; return 0
   fi
 
-  echo -e "\nPackaging: ${toPackage[*]}"
-  for chartDir in "${toPackage[@]}"; do
-    rm -rf "${chartDir}charts/"*.tgz 2>/dev/null || true
-    helm dependency update "${chartDir}" || true
-    helm package "${chartDir}"
-  done
+  echo -e "\nPublishing to gh-pages via a dedicated (detached) worktree ..."
+  local ghp
+  ghp="$(mktemp -d)"
+  git worktree add --force --detach "${ghp}" origin/gh-pages
 
-  echo -e "\nSwitching to gh-pages to commit packages alongside previous versions."
-  git checkout gh-pages
-  # Absolute URLs for new entries (--url); --merge preserves existing entries.
-  helm repo index . --merge index.yaml --url "${REPO_URL}"
-  git add -A "./*.tgz" ./index.yaml
-  git commit -m "Update Helm repository from CI."
-  git push origin gh-pages
+  (
+    cd "${ghp}"
+    # gh-pages must only hold index.yaml + top-level <chart>-<ver>.tgz. Remove any
+    # stray nested chart dirs accidentally published by an earlier revision.
+    if [ -d charts ]; then git rm -r -q --ignore-unmatch charts >/dev/null 2>&1 || true; rm -rf charts; fi
+    cp "${pkgDir}"/*.tgz .
+    helm repo index . --merge index.yaml --url "${REPO_URL}"
+    git add ./*.tgz index.yaml
+    git commit -m "Update Helm repository from CI."
+    git push origin HEAD:gh-pages
+  )
+
+  git worktree remove --force "${ghp}" || true
+  rm -rf "${pkgDir}"
 }
 
 # Execute Helm Release script.


### PR DESCRIPTION
The Chart Release for rudderstack 0.2.0 (#82) failed: `git checkout gh-pages` aborted because `helm dependency update` leaves an untracked vendored `transformer-0.1.0.tgz` that collided with a nested file an earlier run had committed to gh-pages (recursive `git add "*.tgz"` pathspec).

Fix: package into a temp dir and publish from a **detached gh-pages worktree**, and prune stray nested `charts/` from gh-pages so it only holds `index.yaml` + top-level chart archives. Validated end-to-end against an isolated bare remote seeded with the stray file — result: clean gh-pages with `rudderstack-0.2.0.tgz` published and the stray removed.

Merging re-triggers Chart Release and publishes rudderstack 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)