### PR TITLE
fix(rudderstack): gateway before processor on first boot (0.2.1)

### DIFF
--- a/charts/rudderstack/Chart.yaml
+++ b/charts/rudderstack/Chart.yaml
@@ -17,7 +17,7 @@ description: |
 type: application
 
 # Chart version. Bump on every change to the chart/templates.
-version: 0.2.0
+version: 0.2.1
 
 # Deployed rudder-server / rudder-transformer application version (see values).
 appVersion: "1.74.1"

--- a/charts/rudderstack/README.md
+++ b/charts/rudderstack/README.md
@@ -1,6 +1,6 @@
 # rudderstack
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
 
 Breadfast self-hosted RudderStack (Segment-alternative) data plane.
 
@@ -83,7 +83,7 @@ chart carries placeholders only, never plaintext.
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| syncWaves | object | `{"gateway":"2","prereqs":"-1","processor":"1","transformer":"0"}` | ------------------------------------------------------------------------- |
+| syncWaves | object | `{"gateway":"1","prereqs":"-1","processor":"2","transformer":"0"}` | ------------------------------------------------------------------------- |
 | transformer.affinity | object | `{}` |  |
 | transformer.extraEnvVars | list | `[]` |  |
 | transformer.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/rudderstack/templates/NOTES.txt
+++ b/charts/rudderstack/templates/NOTES.txt
@@ -46,6 +46,8 @@ OPERATIONAL CAVEAT - processor failover on hard node failure:
   so the impact is processing/delivery latency, NOT data loss.
 
 First boot on an empty Cloud SQL:
-  gw_* tables are created by the gateway (the writer). The processor opens gw_*
-  read-only and tolerates their absence (its /health Ping is connection-level),
-  so it will not crash-loop before the gateway has started.
+  gw_* tables are created by the GATEWAY (the writer). The processor opens gw_*
+  read-only and PANICS on startup if they don't exist yet (jobsdb
+  recoverFromJournal -> "relation gw_journal does not exist"). The gateway is
+  therefore sequenced BEFORE the processor (sync wave 1 vs 2) so the tables
+  exist first. Once created they persist, so processor restarts are unaffected.

--- a/charts/rudderstack/values.yaml
+++ b/charts/rudderstack/values.yaml
@@ -35,8 +35,12 @@ vault:
 syncWaves:
   prereqs: "-1"      # PriorityClass, ServiceAccount, ConfigMap, the AVP Secrets
   transformer: "0"   # passed to the transformer subchart as .Values.syncWave
-  processor: "1"     # StatefulSet + governing/metrics Services (runs migrations)
-  gateway: "2"       # Deployment + Service + PDB + Ingress
+  # Gateway MUST come before the processor: the gateway is the writer that
+  # creates the gw_* JobsDB tables (incl. gw_journal). The processor opens gw_*
+  # read-only and PANICS on first boot if those tables don't exist yet
+  # (jobsdb recoverFromJournal -> "relation gw_journal does not exist").
+  gateway: "1"       # Deployment + Service + PDB + HTTPRoute (creates gw_* tables)
+  processor: "2"     # StatefulSet + governing/metrics Services (reads gw_*, writes rt/batch_rt/...)
 
 global:
   imagePullSecrets: []


### PR DESCRIPTION
## Problem
First prod sync deadlocked. The processor (StatefulSet, sync wave 1) crash-loops with:
```
panic: pq: relation "gw_journal" does not exist (42P01)
```
Its read-only `gw` JobsDB handle runs `recoverFromJournal` on startup and panics because the `gw_*` tables don't exist. Those tables are created by the **gateway** (the writer) — which was wave 2, so ArgoCD never applied it (wave 1 never went Healthy). DB connectivity/SSL/Vault are all fine (it's a missing-relation, not a connection error).

## Fix
Swap the sync waves so the gateway creates `gw_*` first:
`transformer(0) -> gateway(1) -> processor(2)`. Bumps chart to **0.2.1**. Also corrected the NOTES first-boot note (the processor does NOT tolerate missing gw_* — it panics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)