### PR TITLE
feat(rudderstack): OTel Collector metrics aggregator (0.3.0)

### DIFF
--- a/charts/rudderstack/Chart.yaml
+++ b/charts/rudderstack/Chart.yaml
@@ -17,7 +17,7 @@ description: |
 type: application
 
 # Chart version. Bump on every change to the chart/templates.
-version: 0.2.1
+version: 0.3.0
 
 # Deployed rudder-server / rudder-transformer application version (see values).
 appVersion: "1.74.1"

--- a/charts/rudderstack/README.md
+++ b/charts/rudderstack/README.md
@@ -1,6 +1,6 @@
 # rudderstack
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
 
 Breadfast self-hosted RudderStack (Segment-alternative) data plane.
 
@@ -74,6 +74,20 @@ chart carries placeholders only, never plaintext.
 | ingress.labels | object | `{}` |  |
 | ingress.secretName | string | `""` |  |
 | ingress.tls | bool | `true` |  |
+| metricsAggregator.affinity | object | `{}` |  |
+| metricsAggregator.enabled | bool | `false` |  |
+| metricsAggregator.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metricsAggregator.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |
+| metricsAggregator.image.tag | string | `"0.119.0"` |  |
+| metricsAggregator.nodeSelector | object | `{}` |  |
+| metricsAggregator.podAnnotations | object | `{}` |  |
+| metricsAggregator.port | int | `9182` |  |
+| metricsAggregator.resources.limits.memory | string | `"256Mi"` |  |
+| metricsAggregator.resources.requests.cpu | string | `"100m"` |  |
+| metricsAggregator.resources.requests.memory | string | `"128Mi"` |  |
+| metricsAggregator.scrapeInterval | string | `"30s"` |  |
+| metricsAggregator.serviceName | string | `"rudder-metrics"` |  |
+| metricsAggregator.tolerations | list | `[]` |  |
 | persistence | object | `{"mountPath":"/data/rudderstack"}` | Persistent mount path inside both pods for RUDDER_TMPDIR / recovery files. |
 | priorityClass.create | bool | `true` |  |
 | priorityClass.description | string | `"Breadfast RudderStack ingestion/processing - keep off the eviction list."` |  |

--- a/charts/rudderstack/templates/_helpers.tpl
+++ b/charts/rudderstack/templates/_helpers.tpl
@@ -74,6 +74,15 @@ app.kubernetes.io/component: processor
 {{- printf "%s-processor" (include "rudderstack.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "metricsAggregator.fullname" -}}
+{{- printf "%s-metrics-aggregator" (include "rudderstack.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "metricsAggregator.selectorLabels" -}}
+{{ include "rudderstack.selectorLabels" . }}
+app.kubernetes.io/component: metrics-aggregator
+{{- end -}}
+
 {{/*
 Workspace-token Secret name (AVP-backed unless an existing secret is provided).
 */}}

--- a/charts/rudderstack/templates/metrics-aggregator.yaml
+++ b/charts/rudderstack/templates/metrics-aggregator.yaml
@@ -1,0 +1,210 @@
+{{- if .Values.metricsAggregator.enabled -}}
+{{- $agg := .Values.metricsAggregator -}}
+{{- $name := include "metricsAggregator.fullname" . -}}
+---
+# OpenTelemetry Collector: scrapes every gateway pod + the processor on :9182 and
+# re-exposes a MERGED /metrics on :{{ $agg.port }}, so the control plane's single
+# rudder-metrics scrape sees BOTH ingestion (gateway_*) and processing/router/
+# warehouse/jobsdb metrics. Series are labelled per pod (rudder_component/pod).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.processor | quote }}
+---
+# Namespaced RBAC: the Prometheus receiver's kubernetes_sd (role: pod) needs to
+# list/watch pods in this namespace only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.processor | quote }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.processor | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.processor | quote }}
+data:
+  collector.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: rudder-data-plane
+              scrape_interval: {{ $agg.scrapeInterval }}
+              metrics_path: /metrics
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names: [{{ .Release.Namespace }}]
+              relabel_configs:
+                # keep only this release's gateway + processor pods
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                  regex: {{ include "rudderstack.name" . }}
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+                  regex: {{ .Release.Name }}
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+                  regex: (gateway|processor)
+                  action: keep
+                # scrape only the metrics container port (avoid 8080/8086)
+                - source_labels: [__meta_kubernetes_pod_container_port_number]
+                  regex: "{{ .Values.backend.metricsPort }}"
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_ip]
+                  target_label: __address__
+                  replacement: $1:{{ .Values.backend.metricsPort }}
+                # keep provenance so the control plane can distinguish/aggregate
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+                  target_label: rudder_component
+                - source_labels: [__meta_kubernetes_pod_name]
+                  target_label: pod
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:{{ $agg.port }}
+        metric_expiration: 5m
+        resource_to_telemetry_conversion:
+          enabled: false
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [prometheus]
+---
+apiVersion: {{ include "statefulset.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.processor | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "metricsAggregator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "metricsAggregator.selectorLabels" . | nindent 8 }}
+        {{- include "rudderstack.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ .Files.Get "rudder-config.yaml" | sha256sum | trunc 8 }}-{{ $agg.scrapeInterval }}
+        {{- with $agg.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ $name }}
+      {{- if .Values.priorityClass.create }}
+      priorityClassName: {{ .Values.priorityClass.name }}
+      {{- end }}
+      {{- with $agg.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $agg.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $agg.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}
+      containers:
+        - name: otel-collector
+          image: "{{ $agg.image.repository }}:{{ $agg.image.tag }}"
+          imagePullPolicy: {{ $agg.image.pullPolicy }}
+          args: ["--config=/etc/otelcol/collector.yaml"]
+          ports:
+            - name: metrics
+              containerPort: {{ $agg.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            {{- toYaml $agg.resources | nindent 12 }}
+---
+# rudder-metrics Service -> the aggregator (replaces the processor-only Service).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $agg.serviceName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.processor | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ $agg.port }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "metricsAggregator.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/rudderstack/templates/metrics-service.yaml
+++ b/charts/rudderstack/templates/metrics-service.yaml
@@ -1,10 +1,12 @@
 {{- $base := .Values.backend -}}
-{{- if $base.processor.metricsService.enabled }}
+{{- if and $base.processor.metricsService.enabled (not .Values.metricsAggregator.enabled) }}
 ---
 # Single, stable metrics endpoint scraped by the control plane via one
 # Service-DNS GET on /metrics:9182. Selects the PROCESSOR pod only (single
 # replica), replacing the old EMBEDDED rudderstack-0 target. Do NOT point this
 # at multiple replicas - a single Service-DNS GET cannot aggregate them.
+# NOTE: when metricsAggregator.enabled, the aggregator owns the rudder-metrics
+# Service instead (it merges gateway + processor metrics), so this is skipped.
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/rudderstack/values.yaml
+++ b/charts/rudderstack/values.yaml
@@ -306,6 +306,38 @@ transformer:
   tolerations: []
 
 # ===========================================================================
+# Metrics aggregator (OpenTelemetry Collector).
+# The control plane scrapes ONE endpoint (rudder-metrics:9182). In the split
+# data plane, gateway pods expose gateway_* (ingestion) and the processor
+# exposes proc_/rt_/warehouse/jobsdb_* - disjoint sets. This Collector scrapes
+# ALL gateway pods + the processor on :9182 and re-exposes a MERGED /metrics on
+# :9182, and the rudder-metrics Service is repointed at it. When enabled, the
+# processor's own rudder-metrics Service is not created (this one takes over the
+# name), so the control plane keeps working unchanged.
+# ===========================================================================
+metricsAggregator:
+  enabled: false
+  serviceName: rudder-metrics   # Service name the control plane scrapes
+  port: 9182                    # merged /metrics port exposed to the control plane
+  scrapeInterval: 30s
+  image:
+    repository: otel/opentelemetry-collector-contrib
+    tag: "0.119.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      memory: "256Mi"
+  # Scheduling (defaults: run anywhere; it only needs cluster-network access to
+  # the data-plane pods). Pin to the rudderstack pool via the overlay if desired.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+
+# ===========================================================================
 # PriorityClass for the ingestion-critical workloads (gateway + processor;
 # transformer references it too since gateway readiness depends on it).
 # ===========================================================================


### PR DESCRIPTION
## Why
The control plane's health feature scrapes a **single** endpoint (`RUDDER_SERVER_METRICS_URL=http://rudder-metrics:9182`). In the split data plane the roles expose **disjoint** metrics — gateway pods: `gateway_*` (ingestion); processor: `proc_/rt_/warehouse/jobsdb_*`. Today `rudder-metrics` points at the processor only, so the control plane can't see gateway ingestion metrics (verified in-cluster). In non-prod (embedded) one pod had everything, so it worked.

## What
Opt-in **OpenTelemetry Collector** (`metricsAggregator.enabled`) that:
- Prometheus-scrapes every gateway pod + the processor on `:9182` (kubernetes_sd, namespaced RBAC).
- Re-exposes a **merged** `/metrics` on `:9182`, series labelled `rudder_component`/`pod`.
- Owns the `rudder-metrics` Service (the processor-only Service is suppressed when enabled).

Control plane and `RUDDER_SERVER_METRICS_URL` stay unchanged. Chart **0.2.1 → 0.3.0**.

## Validation
- `helm lint` clean; render with `metricsAggregator.enabled=true` yields the Collector (Deploy/CM/SA/Role/RoleBinding) and a single `rudder-metrics` Service selecting the aggregator.
- Verified per-pod metric families in prod: gateway → `gateway_*`; processor → `proc_/rt_/brt_/warehouse/jobsdb_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)