### PR TITLE
feat(service): gatewayAPI trafficRouting for Argo Rollouts canary (v0.3.0)

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.67
+version: 0.3.0
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -12,43 +12,6 @@ When gateway.enabled is true, the chart creates **Gateway API** resources separa
 
 Ingress resources are unchanged; you can use Ingress only, Gateway only, or both.
 
-## Argo Rollouts canary traffic routing
-
-`argorollouts.trafficRouting` selects how `setWeight` steps shift traffic:
-
-- **`nginx`** (default, legacy): `trafficRouting.nginx.stableIngress` — only shifts traffic that flows
-  through the nginx Ingress. Use for services still fronted by nginx.
-- **`gatewayAPI`**: uses the [`argoproj-labs/gatewayAPI`](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)
-  plugin. The Rollout weights the **stable** (`<fullname>-service`) vs **canary**
-  (`<fullname>-service-canary`) backendRefs on this service's Gateway API HTTPRoute(s), so `setWeight`
-  shifts **real** Gateway traffic. This makes `dynamicStableScale` safe (stable capacity tracks real
-  traffic). Use for services whose real traffic flows through a GKE Gateway.
-
-Requirements / behavior for `gatewayAPI`:
-
-- `gateway.enabled: true` (or `ingress.type: gateway`) must render the HTTPRoute(s), and the
-  `argoproj-labs/gatewayAPI` plugin must be installed in the argo-rollouts controller.
-- When `argorollouts.enabled` **and** `trafficRouting: gatewayAPI`, every HTTPRoute rule that targets
-  this service's own Service is rendered with **both** stable+canary backendRefs (weights `100`/`0` at
-  rest; the plugin owns them during a rollout). This is required — the plugin errors on any managed
-  rule missing the canary ref. Rules targeting a *different* service are left single-ref (do not point
-  a canaried route's rules at another service).
-- The Rollout's plugin block auto-derives the list of HTTPRoute names the chart renders (per host,
-  chunked at `gateway.maxRulesPerRoute`). Override with `argorollouts.gatewayAPI.httpRoutes` /
-  `httpRouteNamespace` only if needed.
-- **GitOps note:** the plugin patches HTTPRoute `backendRefs[].weight` in place. If your ArgoCD
-  Application has `selfHeal: true`, add an `ignoreDifferences` for
-  `gateway.networking.k8s.io/HTTPRoute` at `.spec.rules[].backendRefs[].weight`, or ArgoCD will revert
-  the plugin mid-rollout.
-
-Example:
-
-```yaml
-argorollouts:
-  enabled: true
-  trafficRouting: gatewayAPI   # default is nginx
-```
-
 When networkPolicy.enabled and networkPolicy.internetOnly.enabled are true, the chart creates an egress-only
 NetworkPolicy that allows DNS and public internet traffic while excluding common private/internal CIDRs.
 NetworkPolicy works by IP/CIDR, so add the actual cluster Pod, Service, and internal VPC CIDRs to
@@ -73,10 +36,13 @@ networkPolicy.internetOnly.ipBlock.except when they are outside the defaults.
 | argoPreSyncValidator | object | `{"annotations":{},"backoffLimit":1,"command":["php","-l","/vault/secrets/wp-config.php"],"enabled":false,"ttlSecondsAfterFinished":60}` | If true, create ArgoCD PreSync job to validate environment variables injected from Vault |
 | argorollouts.dynamicStableScale | bool | `true` |  |
 | argorollouts.enabled | bool | `false` |  |
+| argorollouts.gatewayAPI.httpRouteNamespace | string | `""` | Namespace of the HTTPRoute(s) the plugin manages. Empty = the release namespace. |
+| argorollouts.gatewayAPI.httpRoutes | list | `[]` | Explicit list of HTTPRoute names for the plugin to manage. Leave empty (recommended) to    auto-derive the names from the HTTPRoutes this chart renders (matches the chunking in    httproute.yaml). Set only to override. |
 | argorollouts.steps[0].setWeight | int | `20` |  |
 | argorollouts.steps[1].pause.duration | string | `"1m"` |  |
 | argorollouts.steps[2].setWeight | int | `60` |  |
 | argorollouts.steps[3].pause | object | `{}` |  |
+| argorollouts.trafficRouting | string | `"nginx"` | Canary traffic router. "nginx" (default, legacy) keeps the historical    trafficRouting.nginx.stableIngress behavior. "gatewayAPI" switches the Rollout to the    argoproj-labs/gatewayAPI plugin, which weights the stable vs canary backendRefs on this    service's Gateway API HTTPRoute(s) so setWeight shifts REAL traffic. "gatewayAPI" requires    gateway.enabled=true (or ingress.type=gateway) AND the plugin installed in the controller. |
 | autoscaling.enabled | bool | `false` |  |
 | containerEnv | map | `[]` | Environment variable map |
 | cronJob | bool | `{"create":false}` | If true, Creates CronJob resource |

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.2.67](https://img.shields.io/badge/Version-0.2.67-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes.
 
@@ -11,6 +11,43 @@ When gateway.enabled is true, the chart creates **Gateway API** resources separa
 - **GCPBackendPolicy** (networking.gke.io/v1) – binds a Cloud Armor security policy to the Gateway backend Service when gateway.backendPolicy.enabled is true.
 
 Ingress resources are unchanged; you can use Ingress only, Gateway only, or both.
+
+## Argo Rollouts canary traffic routing
+
+`argorollouts.trafficRouting` selects how `setWeight` steps shift traffic:
+
+- **`nginx`** (default, legacy): `trafficRouting.nginx.stableIngress` — only shifts traffic that flows
+  through the nginx Ingress. Use for services still fronted by nginx.
+- **`gatewayAPI`**: uses the [`argoproj-labs/gatewayAPI`](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)
+  plugin. The Rollout weights the **stable** (`<fullname>-service`) vs **canary**
+  (`<fullname>-service-canary`) backendRefs on this service's Gateway API HTTPRoute(s), so `setWeight`
+  shifts **real** Gateway traffic. This makes `dynamicStableScale` safe (stable capacity tracks real
+  traffic). Use for services whose real traffic flows through a GKE Gateway.
+
+Requirements / behavior for `gatewayAPI`:
+
+- `gateway.enabled: true` (or `ingress.type: gateway`) must render the HTTPRoute(s), and the
+  `argoproj-labs/gatewayAPI` plugin must be installed in the argo-rollouts controller.
+- When `argorollouts.enabled` **and** `trafficRouting: gatewayAPI`, every HTTPRoute rule that targets
+  this service's own Service is rendered with **both** stable+canary backendRefs (weights `100`/`0` at
+  rest; the plugin owns them during a rollout). This is required — the plugin errors on any managed
+  rule missing the canary ref. Rules targeting a *different* service are left single-ref (do not point
+  a canaried route's rules at another service).
+- The Rollout's plugin block auto-derives the list of HTTPRoute names the chart renders (per host,
+  chunked at `gateway.maxRulesPerRoute`). Override with `argorollouts.gatewayAPI.httpRoutes` /
+  `httpRouteNamespace` only if needed.
+- **GitOps note:** the plugin patches HTTPRoute `backendRefs[].weight` in place. If your ArgoCD
+  Application has `selfHeal: true`, add an `ignoreDifferences` for
+  `gateway.networking.k8s.io/HTTPRoute` at `.spec.rules[].backendRefs[].weight`, or ArgoCD will revert
+  the plugin mid-rollout.
+
+Example:
+
+```yaml
+argorollouts:
+  enabled: true
+  trafficRouting: gatewayAPI   # default is nginx
+```
 
 When networkPolicy.enabled and networkPolicy.internetOnly.enabled are true, the chart creates an egress-only
 NetworkPolicy that allows DNS and public internet traffic while excluding common private/internal CIDRs.

--- a/charts/service/templates/_helpers.tpl
+++ b/charts/service/templates/_helpers.tpl
@@ -60,6 +60,43 @@ app.kubernetes.io/name: {{ include "service.name" . }}
 {{- end }}
 
 {{/*
+Comma-separated list of HTTPRoute names this chart renders (see templates/httproute.yaml).
+MUST stay in sync with the naming + chunking in httproute.yaml: one HTTPRoute sequence per host,
+chunked at gateway.maxRulesPerRoute (default 16), named "<fullname>-httproute-<hostIdx>-<chunkIdx>".
+Used by the Rollout gatewayAPI trafficRouting plugin block to reference every route it must manage.
+*/}}
+{{- define "service.httpRouteNames" -}}
+{{- $fullName := include "service.fullname" . -}}
+{{- $names := list -}}
+{{- $useGatewayBlock := and .Values.gateway.enabled .Values.gateway.hosts -}}
+{{- $useIngressGateway := and .Values.ingress.enabled (eq (.Values.ingress.type | default "") "gateway") .Values.ingress.hosts -}}
+{{- $counts := list -}}
+{{- $maxRules := 16 -}}
+{{- if $useGatewayBlock -}}
+  {{- $maxRules = int (.Values.gateway.maxRulesPerRoute | default 16) -}}
+  {{- $gh := .Values.gateway.hosts -}}
+  {{- if and $gh (gt (len $gh) 0) (kindIs "string" (index $gh 0)) -}}
+    {{- $n := len (.Values.gateway.paths | default list) -}}
+    {{- range $gh -}}{{- $counts = append $counts $n -}}{{- end -}}
+  {{- else -}}
+    {{- range $gh -}}{{- $counts = append $counts (len (.paths | default list)) -}}{{- end -}}
+  {{- end -}}
+{{- else if $useIngressGateway -}}
+  {{- $maxRules = int (.Values.ingress.gateway.maxRulesPerRoute | default 16) -}}
+  {{- range .Values.ingress.hosts -}}{{- $counts = append $counts (len (.paths | default list)) -}}{{- end -}}
+{{- end -}}
+{{- range $hIdx, $nRules := $counts -}}
+  {{- if gt (int $nRules) 0 -}}
+    {{- $chunkCount := div (add (int $nRules) (sub $maxRules 1)) $maxRules -}}
+    {{- range $cIdx := until (int $chunkCount) -}}
+      {{- $names = append $names (printf "%s-httproute-%d-%d" $fullName (int $hIdx) (int $cIdx)) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- join "," $names -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "service.serviceAccountName" -}}

--- a/charts/service/templates/argo-rollouts.yaml
+++ b/charts/service/templates/argo-rollouts.yaml
@@ -40,8 +40,24 @@ spec:
           app.kubernetes.io/part-of: canary
           role: canary
       trafficRouting:
+      {{- if eq (.Values.argorollouts.trafficRouting | default "nginx") "gatewayAPI" }}
+        {{- $explicit := .Values.argorollouts.gatewayAPI.httpRoutes | default list }}
+        {{- $derived := splitList "," (include "service.httpRouteNames" .) | compact }}
+        {{- $routes := ternary $explicit $derived (gt (len $explicit) 0) }}
+        {{- if not $routes }}
+          {{- fail "argorollouts.trafficRouting=gatewayAPI requires either gateway/ingress-gateway HTTPRoutes to be rendered or an explicit argorollouts.gatewayAPI.httpRoutes list" }}
+        {{- end }}
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoutes:
+            {{- range $routes }}
+              - name: {{ . }}
+            {{- end }}
+            namespace: {{ .Values.argorollouts.gatewayAPI.httpRouteNamespace | default .Release.Namespace }}
+      {{- else }}
         nginx:
           stableIngress: {{ include "service.fullname" . }}-ingress
+      {{- end }}
       steps:
       {{- with .Values.argorollouts.steps }}
         {{- toYaml . | nindent 8 }}

--- a/charts/service/templates/httproute.yaml
+++ b/charts/service/templates/httproute.yaml
@@ -4,6 +4,11 @@
 {{- $defaultSvcName := printf "%s-service" (include "service.fullname" .) -}}
 {{- $fullName := include "service.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- /* When the Rollout uses the gatewayAPI trafficRouter plugin, every rule that targets the
+       stable Service must also carry the canary Service backendRef (the plugin errors on any
+       managed rule lacking it) and both must be weighted; the plugin owns the weights at runtime. */ -}}
+{{- $gwCanary := and .Values.argorollouts.enabled (eq (.Values.argorollouts.trafficRouting | default "nginx") "gatewayAPI") -}}
+{{- $canarySvcName := printf "%s-service-canary" $fullName -}}
 {{- $parentRefs := "" -}}
 {{- $hosts := list -}}
 {{- $annotations := dict -}}
@@ -159,9 +164,20 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $stableName := .serviceName | default $defaultSvcName }}
+      {{- $port := .servicePort | default $svcPort }}
+      {{- $canaryOnRule := and $gwCanary (eq $stableName $defaultSvcName) }}
       backendRefs:
-      - name: {{ .serviceName | default $defaultSvcName }}
-        port: {{ .servicePort | default $svcPort }}
+      - name: {{ $stableName }}
+        port: {{ $port }}
+        {{- if $canaryOnRule }}
+        weight: 100
+        {{- end }}
+      {{- if $canaryOnRule }}
+      - name: {{ $canarySvcName }}
+        port: {{ $port }}
+        weight: 0
+      {{- end }}
     {{ end }}
     {{- end -}}
   {{- end -}}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -257,6 +257,19 @@ nodeTolerations: []
 argorollouts:
   dynamicStableScale: true
   enabled: false
+  # -- Canary traffic router. "nginx" (default, legacy) keeps the historical
+  #    trafficRouting.nginx.stableIngress behavior. "gatewayAPI" switches the Rollout to the
+  #    argoproj-labs/gatewayAPI plugin, which weights the stable vs canary backendRefs on this
+  #    service's Gateway API HTTPRoute(s) so setWeight shifts REAL traffic. "gatewayAPI" requires
+  #    gateway.enabled=true (or ingress.type=gateway) AND the plugin installed in the controller.
+  trafficRouting: nginx
+  gatewayAPI:
+    # -- Namespace of the HTTPRoute(s) the plugin manages. Empty = the release namespace.
+    httpRouteNamespace: ""
+    # -- Explicit list of HTTPRoute names for the plugin to manage. Leave empty (recommended) to
+    #    auto-derive the names from the HTTPRoutes this chart renders (matches the chunking in
+    #    httproute.yaml). Set only to override.
+    httpRoutes: []
   steps:
   - setWeight: 20
   - pause:


### PR DESCRIPTION
## What
Adds `argorollouts.trafficRouting: nginx|gatewayAPI` to the shared `service` chart (bumped **0.2.67 → 0.3.0**). Default `nginx` keeps existing behavior; `gatewayAPI` switches the Rollout to the [`argoproj-labs/gatewayAPI`](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi) plugin.

## Why
With `gatewayAPI`, `setWeight` weights the stable (`<svc>-service`) vs canary (`<svc>-service-canary`) backendRefs on the service's Gateway API HTTPRoute(s), shifting **real** GKE Gateway traffic — which makes `dynamicStableScale` safe. Fixes the nginx-canary-that-moves-no-traffic bug behind the node-app/picker incidents.

## Changes
- `templates/argo-rollouts.yaml`: renders `trafficRouting.plugins."argoproj-labs/gatewayAPI"` with the auto-derived `httpRoutes` list + namespace, else the legacy `nginx` block.
- `templates/httproute.yaml`: when gatewayAPI canary is active, every rule targeting the stable Service gets **both** stable+canary weighted backendRefs (100/0 at rest; the plugin owns them at runtime). Required — the plugin errors on any managed rule missing the canary ref.
- `templates/_helpers.tpl`: `service.httpRouteNames` mirrors the per-host/`maxRulesPerRoute` chunking so the Rollout references exactly the HTTPRoutes this chart renders.
- `values.yaml` / `README.md` / `Chart.yaml`.

## Compatibility & verification
- **Backward compatible**: default `nginx`; analysis templates, steps, and notification annotations unchanged; Deployment still gated off when rollouts enabled.
- `helm lint` clean. `helm template` verified: nginx path byte-identical; node-app `testing` (36 rules → 3 HTTPRoute chunks) renders both refs on **every** rule, derived route names match the rendered HTTPRoutes exactly (incl. a URLRewrite-filtered rule), namespace resolves correctly.

## Consumer note (GitOps)
The plugin patches HTTPRoute `backendRefs[].weight` in place — ArgoCD Applications with `selfHeal: true` need `ignoreDifferences` on `gateway.networking.k8s.io/HTTPRoute` `.spec.rules[].backendRefs[].weight` (handled in the gitops PR for non-prod). After merge, publish v0.3.0 and bump consumers' `targetRevision`.

## Related PRs
- external-tools: installs the gatewayAPI plugin in the controller (ArgoCD, non-prod).
- gitops: nonprod ApplicationSet `ignoreDifferences` + migration runbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)