### PR TITLE
Expose OneUptime incident Google Chat space values

### DIFF
--- a/charts/oneuptime/Chart.yaml
+++ b/charts/oneuptime/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Fork pin: upstream OneUptime 11.0.1 chart + Breadfast serviceAccount/googleChat
 # additions. `-bf.N` mirrors the image-tag convention; bump N on every re-sync.
-version: 11.0.1-bf.1
+version: 11.0.1-bf.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/oneuptime/README.md
+++ b/charts/oneuptime/README.md
@@ -1,6 +1,6 @@
 # oneuptime
 
-![Version: 11.0.1-bf.1](https://img.shields.io/badge/Version-11.0.1--bf.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.0.1](https://img.shields.io/badge/AppVersion-11.0.1-informational?style=flat-square)
+![Version: 11.0.1-bf.2](https://img.shields.io/badge/Version-11.0.1--bf.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.0.1](https://img.shields.io/badge/AppVersion-11.0.1-informational?style=flat-square)
 
 The Complete Open-Source Observability Platform
 
@@ -225,6 +225,8 @@ The Complete Open-Source Observability Platform
 | global.clusterDomain | string | `"cluster.local"` |  |
 | global.storageClass | string | `nil` |  |
 | googleChat.customerId | string | `"customers/my_customer"` |  |
+| googleChat.incidentResponderSpaceName | string | `""` |  |
+| googleChat.incidentUpdatesSpaceName | string | `""` |  |
 | googleChat.onCallCommandId | string | `""` |  |
 | googleChat.projectNumber | string | `""` |  |
 | home.containerSecurityContext | object | `{}` |  |

--- a/charts/oneuptime/templates/_helpers.tpl
+++ b/charts/oneuptime/templates/_helpers.tpl
@@ -66,6 +66,10 @@ app/worker pod specs so a created SA and its consumers always agree on the name.
   value: {{ $.Values.googleChat.customerId | default "customers/my_customer" | quote }}
 - name: GOOGLE_CHAT_ONCALL_COMMAND_ID
   value: {{ $.Values.googleChat.onCallCommandId | default "" | quote }}
+- name: GOOGLE_CHAT_INCIDENT_RESPONDER_SPACE_NAME
+  value: {{ $.Values.googleChat.incidentResponderSpaceName | default "" | quote }}
+- name: GOOGLE_CHAT_INCIDENT_UPDATES_SPACE_NAME
+  value: {{ $.Values.googleChat.incidentUpdatesSpaceName | default "" | quote }}
 
 {{- if $.Values.openTelemetryExporter.endpoint }}
 - name: OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT

--- a/charts/oneuptime/values.schema.json
+++ b/charts/oneuptime/values.schema.json
@@ -2274,6 +2274,18 @@
                         "string",
                         "null"
                     ]
+                },
+                "incidentResponderSpaceName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "incidentUpdatesSpaceName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false

--- a/charts/oneuptime/values.yaml
+++ b/charts/oneuptime/values.yaml
@@ -1018,6 +1018,8 @@ googleChat:
   projectNumber: ""
   customerId: "customers/my_customer"
   onCallCommandId: ""
+  incidentResponderSpaceName: ""
+  incidentUpdatesSpaceName: ""
 
 # GitHub Example Configuration
 # gitHubApp:


### PR DESCRIPTION
## Summary
- expose OneUptime incident Google Chat responder/update space values in the packaged chart
- wire `GOOGLE_CHAT_INCIDENT_RESPONDER_SPACE_NAME` and `GOOGLE_CHAT_INCIDENT_UPDATES_SPACE_NAME` from `googleChat.*` values
- allow the new values in `values.schema.json` and document them in the chart README
- bump OneUptime chart version to `11.0.1-bf.2` for packaging/release

## Validation
- `sh scripts/helm-docs.sh`
- `helm lint charts/oneuptime`
- `helm template oneuptime charts/oneuptime -f /Users/macbook/breadfast/repos/external-tools/oneuptime/prod/values.yaml --show-only templates/app.yaml | rg -A1 "GOOGLE_CHAT_INCIDENT"` rendered `oncall-rotation` and `incidents`

## Related
- Breadfast/oneuptime#11