### PR TITLE
fix(rudderstack): preserve metric names in OTel aggregator

### DIFF
--- a/charts/rudderstack/Chart.yaml
+++ b/charts/rudderstack/Chart.yaml
@@ -17,7 +17,7 @@ description: |
 type: application
 
 # Chart version. Bump on every change to the chart/templates.
-version: 0.3.0
+version: 0.3.1
 
 # Deployed rudder-server / rudder-transformer application version (see values).
 appVersion: "1.74.1"

--- a/charts/rudderstack/README.md
+++ b/charts/rudderstack/README.md
@@ -1,6 +1,6 @@
 # rudderstack
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.74.1](https://img.shields.io/badge/AppVersion-1.74.1-informational?style=flat-square)
 
 Breadfast self-hosted RudderStack (Segment-alternative) data plane.
 
@@ -74,8 +74,8 @@ chart carries placeholders only, never plaintext.
 | ingress.labels | object | `{}` |  |
 | ingress.secretName | string | `""` |  |
 | ingress.tls | bool | `true` |  |
-| metricsAggregator.affinity | object | `{}` |  |
 | metricsAggregator.addMetricSuffixes | bool | `false` |  |
+| metricsAggregator.affinity | object | `{}` |  |
 | metricsAggregator.enabled | bool | `false` |  |
 | metricsAggregator.image.pullPolicy | string | `"IfNotPresent"` |  |
 | metricsAggregator.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |

--- a/charts/rudderstack/README.md
+++ b/charts/rudderstack/README.md
@@ -75,6 +75,7 @@ chart carries placeholders only, never plaintext.
 | ingress.secretName | string | `""` |  |
 | ingress.tls | bool | `true` |  |
 | metricsAggregator.affinity | object | `{}` |  |
+| metricsAggregator.addMetricSuffixes | bool | `false` |  |
 | metricsAggregator.enabled | bool | `false` |  |
 | metricsAggregator.image.pullPolicy | string | `"IfNotPresent"` |  |
 | metricsAggregator.image.repository | string | `"otel/opentelemetry-collector-contrib"` |  |

--- a/charts/rudderstack/templates/metrics-aggregator.yaml
+++ b/charts/rudderstack/templates/metrics-aggregator.yaml
@@ -103,6 +103,7 @@ data:
       prometheus:
         endpoint: 0.0.0.0:{{ $agg.port }}
         metric_expiration: 5m
+        add_metric_suffixes: {{ $agg.addMetricSuffixes }}
         resource_to_telemetry_conversion:
           enabled: false
     extensions:
@@ -136,7 +137,7 @@ spec:
         {{- include "metricsAggregator.selectorLabels" . | nindent 8 }}
         {{- include "rudderstack.labels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ .Files.Get "rudder-config.yaml" | sha256sum | trunc 8 }}-{{ $agg.scrapeInterval }}
+        checksum/config: {{ printf "%s-%s" (toYaml $agg) (toString .Values.backend.metricsPort) | sha256sum | trunc 8 }}
         {{- with $agg.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/rudderstack/values.yaml
+++ b/charts/rudderstack/values.yaml
@@ -320,6 +320,13 @@ metricsAggregator:
   serviceName: rudder-metrics   # Service name the control plane scrapes
   port: 9182                    # merged /metrics port exposed to the control plane
   scrapeInterval: 30s
+  # Keep the merged endpoint's metric names identical to the direct rudder-server
+  # /metrics output. The Prometheus exporter default appends type/unit suffixes
+  # (for example `_total` on counters), which breaks consumers that were written
+  # against the direct RudderStack exposition used by the all-in-one topology.
+  # NOTE: pinned collector 0.119.0 supports add_metric_suffixes; newer collector
+  # versions prefer translation_strategy: UnderscoreEscapingWithoutSuffixes.
+  addMetricSuffixes: false
   image:
     repository: otel/opentelemetry-collector-contrib
     tag: "0.119.0"


### PR DESCRIPTION
## Summary
- configure the RudderStack metrics aggregator's OTel Prometheus exporter with add_metric_suffixes: false so merged metrics keep the direct rudder-server names
- make the metrics-aggregator pod checksum derive from aggregator config so ConfigMap changes roll the pod
- bump the rudderstack chart to 0.3.1 and document the new value

## Context
Production uses the split gateway/processor topology and scrapes the OTel-merged rudder-metrics:9182 endpoint. Direct rudder-server metrics expose counters such as proc_event_filter_out_count, while the OTel re-export was adding Prometheus type suffixes such as proc_event_filter_out_count_total. Non-prod did not hit this because it scrapes an all-in-one pod directly.

## Validation
- helm lint charts/rudderstack -f /Users/macbook/breadfast/repos/external-tools/rudderstack/prod/values.yaml
- helm template rudderstack charts/rudderstack --namespace rudderstack -f /Users/macbook/breadfast/repos/external-tools/rudderstack/prod/values.yaml --show-only templates/metrics-aggregator.yaml
- docker run --rm -v /private/tmp/rudder-otel-collector-validate.yaml:/etc/otelcol/collector.yaml:ro otel/opentelemetry-collector-contrib:0.119.0 validate --config=/etc/otelcol/collector.yaml