### PR TITLE
feat(service): Istio east-west canary + resilience (v0.4.0)

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes.
 
@@ -38,6 +38,10 @@ networkPolicy.internetOnly.ipBlock.except when they are outside the defaults.
 | argorollouts.enabled | bool | `false` |  |
 | argorollouts.gatewayAPI.httpRouteNamespace | string | `""` | Namespace of the HTTPRoute(s) the plugin manages. Empty = the release namespace. |
 | argorollouts.gatewayAPI.httpRoutes | list | `[]` | Explicit list of HTTPRoute names for the plugin to manage. Leave empty (recommended) to    auto-derive the names from the HTTPRoutes this chart renders (matches the chunking in    httproute.yaml). Set only to override. |
+| argorollouts.istio | object | `{"enabled":false,"retries":{},"timeout":"","trafficPolicy":{}}` | Istio EAST-WEST canary. When enabled (with argorollouts.enabled), the Rollout also weights    in-cluster (service-to-service) traffic via Istio, composed with the north-south router    (trafficRouting above). The chart renders a canary-ready VirtualService ("primary" route with    stable/canary weighted subsets) and a DestinationRule (subsets stable/canary). Requires the    workload to run in an Istio-injected namespace. The VirtualService timeout/retries and the    DestinationRule trafficPolicy also provide resilience (timeouts, circuit breaking) to callers. |
+| argorollouts.istio.retries | object | `{}` | HTTP retries on the VirtualService (Istio HTTPRetry), e.g.    {attempts: 2, perTryTimeout: "800ms", retryOn: "5xx,reset,connect-failure"} |
+| argorollouts.istio.timeout | string | `""` | HTTP route timeout on the VirtualService (e.g. "2s"). Empty = no timeout. |
+| argorollouts.istio.trafficPolicy | object | `{}` | DestinationRule trafficPolicy for resilience/circuit breaking (connectionPool +    outlierDetection). Argo Rollouts only edits the subsets, leaving this intact. |
 | argorollouts.steps[0].setWeight | int | `20` |  |
 | argorollouts.steps[1].pause.duration | string | `"1m"` |  |
 | argorollouts.steps[2].setWeight | int | `60` |  |

--- a/charts/service/templates/argo-rollouts.yaml
+++ b/charts/service/templates/argo-rollouts.yaml
@@ -35,10 +35,14 @@ spec:
         labels:
           app.kubernetes.io/part-of: stable
           role: stable
+          # Istio canonical revision (falls back to the `version` label) — lets Istio telemetry
+          # (istio_requests_total) and DestinationRule subsets split canary vs stable.
+          version: stable
       canaryMetadata:
         labels:
           app.kubernetes.io/part-of: canary
           role: canary
+          version: canary
       trafficRouting:
       {{- if eq (.Values.argorollouts.trafficRouting | default "nginx") "gatewayAPI" }}
         {{- $explicit := .Values.argorollouts.gatewayAPI.httpRoutes | default list }}
@@ -57,6 +61,20 @@ spec:
       {{- else }}
         nginx:
           stableIngress: {{ include "service.fullname" . }}-ingress
+      {{- end }}
+      {{- if .Values.argorollouts.istio.enabled }}
+        {{- /* East-west (in-cluster) canary via Istio, composed with the north-south router above.
+               Argo Rollouts weights the VirtualService "primary" route and manages the
+               DestinationRule subsets (canary/stable) in lockstep with the north-south weight. */}}
+        istio:
+          virtualService:
+            name: {{ include "service.fullname" . }}
+            routes:
+              - primary
+          destinationRule:
+            name: {{ include "service.fullname" . }}
+            stableSubsetName: stable
+            canarySubsetName: canary
       {{- end }}
       steps:
       {{- with .Values.argorollouts.steps }}

--- a/charts/service/templates/destinationRule.yaml
+++ b/charts/service/templates/destinationRule.yaml
@@ -1,4 +1,29 @@
-{{ if .Values.destinationRule.enabled }}
+{{- if and .Values.argorollouts.enabled .Values.argorollouts.istio.enabled }}
+{{- /* Canary-ready DestinationRule for Istio east-west traffic routing.
+       Argo Rollouts updates the subsets with the rollouts-pod-template-hash at each step; the
+       `version` labels below (also set on the pods via canary/stableMetadata) give correct
+       selection before/independent of that. trafficPolicy carries resilience (circuit breaking). */}}
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  host: {{ include "service.fullname" . }}-service
+  subsets:
+    - name: stable
+      labels:
+        version: stable
+    - name: canary
+      labels:
+        version: canary
+  {{- with .Values.argorollouts.istio.trafficPolicy }}
+  trafficPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- else if .Values.destinationRule.enabled }}
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
@@ -10,4 +35,4 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
-{{ end }}
+{{- end }}

--- a/charts/service/templates/virtualService.yaml
+++ b/charts/service/templates/virtualService.yaml
@@ -1,4 +1,36 @@
-{{ if .Values.virtualService.enabled }}
+{{- if and .Values.argorollouts.enabled .Values.argorollouts.istio.enabled }}
+{{- /* Canary-ready VirtualService for Istio east-west traffic routing. The "primary" route holds
+       two weighted subset destinations (stable/canary); Argo Rollouts sets the weights each step.
+       timeout/retries provide resilience to in-cluster callers (e.g. picker-service -> node-app). */}}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "service.fullname" . }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  hosts:
+    - {{ include "service.fullname" . }}-service
+  http:
+    - name: primary
+      {{- with .Values.argorollouts.istio.timeout }}
+      timeout: {{ . }}
+      {{- end }}
+      {{- with .Values.argorollouts.istio.retries }}
+      retries:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      route:
+        - destination:
+            host: {{ include "service.fullname" . }}-service
+            subset: stable
+          weight: 100
+        - destination:
+            host: {{ include "service.fullname" . }}-service
+            subset: canary
+          weight: 0
+---
+{{- else if .Values.virtualService.enabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -13,4 +45,4 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
-{{ end }}
+{{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -270,6 +270,22 @@ argorollouts:
     #    auto-derive the names from the HTTPRoutes this chart renders (matches the chunking in
     #    httproute.yaml). Set only to override.
     httpRoutes: []
+  # -- Istio EAST-WEST canary. When enabled (with argorollouts.enabled), the Rollout also weights
+  #    in-cluster (service-to-service) traffic via Istio, composed with the north-south router
+  #    (trafficRouting above). The chart renders a canary-ready VirtualService ("primary" route with
+  #    stable/canary weighted subsets) and a DestinationRule (subsets stable/canary). Requires the
+  #    workload to run in an Istio-injected namespace. The VirtualService timeout/retries and the
+  #    DestinationRule trafficPolicy also provide resilience (timeouts, circuit breaking) to callers.
+  istio:
+    enabled: false
+    # -- HTTP route timeout on the VirtualService (e.g. "2s"). Empty = no timeout.
+    timeout: ""
+    # -- HTTP retries on the VirtualService (Istio HTTPRetry), e.g.
+    #    {attempts: 2, perTryTimeout: "800ms", retryOn: "5xx,reset,connect-failure"}
+    retries: {}
+    # -- DestinationRule trafficPolicy for resilience/circuit breaking (connectionPool +
+    #    outlierDetection). Argo Rollouts only edits the subsets, leaving this intact.
+    trafficPolicy: {}
   steps:
   - setWeight: 20
   - pause:


### PR DESCRIPTION
## What
Adds **`argorollouts.istio`** so a Rollout can canary **east-west (in-cluster) traffic via Istio** *composed with* the existing north-south router (`gatewayAPI`/`nginx`). Argo Rollouts weights **both planes in lockstep** at each `setWeight`. Bumps chart **0.3.0 → 0.4.0**.

## Why
With GKE-Gateway-only canarying, only north-south (external) traffic is split; internal callers (e.g. `picker-service → node-app`) always hit stable, so the analysis never sees the internal path and a bad canary only surfaces at full promotion. Both node-app and picker already run Istio sidecars, so adding Istio east-west routing lets internal traffic participate in the canary — and the same VS/DR give us **timeouts + circuit breaking** for the picker→node-app resilience ask.

## Changes
- `templates/argo-rollouts.yaml`: render `trafficRouting.istio` (VirtualService `primary` route + DestinationRule subsets `stable`/`canary`) when `argorollouts.istio.enabled`, alongside the north-south block. Add `version: stable|canary` labels to canary/stable metadata so Istio's `destination_canonical_revision` (and the DR subsets) split canary vs stable.
- `templates/virtualService.yaml`: canary-ready VS — one `primary` route with weighted stable/canary subset destinations (Argo Rollouts owns the weights), plus optional `timeout`/`retries`.
- `templates/destinationRule.yaml`: canary-ready DR — subsets `stable`/`canary` + `trafficPolicy` (connectionPool + outlierDetection for circuit breaking). Generic templates preserved when istio canary is off.
- `values.yaml`: `argorollouts.istio { enabled, timeout, retries, trafficPolicy }`.

## Compatibility & verification
- **Backward compatible**: default off; `helm template` confirms rollouts-off and gatewayAPI-only/nginx configs render **no** VirtualService/DestinationRule and **no** `istio:` block.
- Combined render verified: Rollout `trafficRouting` shows **both** `plugins.argoproj-labs/gatewayAPI` **and** `istio`; VS has weighted `primary` route + timeout/retries; DR has subsets + circuit-breaking trafficPolicy.
- `helm lint` clean; `helm-docs` check passes.

## Consumers
Enable via `argorollouts.istio.enabled: true` (+ optional `timeout`/`retries`/`trafficPolicy`) on a Rollout service in an Istio-injected namespace. Publish 0.4.0 and bump consumers' `targetRevision`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)