### PR TITLE
refactor(service): standalone top-level istio block (VS/DR + resilience), v0.5.0

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes.
 
@@ -38,10 +38,6 @@ networkPolicy.internetOnly.ipBlock.except when they are outside the defaults.
 | argorollouts.enabled | bool | `false` |  |
 | argorollouts.gatewayAPI.httpRouteNamespace | string | `""` | Namespace of the HTTPRoute(s) the plugin manages. Empty = the release namespace. |
 | argorollouts.gatewayAPI.httpRoutes | list | `[]` | Explicit list of HTTPRoute names for the plugin to manage. Leave empty (recommended) to    auto-derive the names from the HTTPRoutes this chart renders (matches the chunking in    httproute.yaml). Set only to override. |
-| argorollouts.istio | object | `{"enabled":false,"retries":{},"timeout":"","trafficPolicy":{}}` | Istio EAST-WEST canary. When enabled (with argorollouts.enabled), the Rollout also weights    in-cluster (service-to-service) traffic via Istio, composed with the north-south router    (trafficRouting above). The chart renders a canary-ready VirtualService ("primary" route with    stable/canary weighted subsets) and a DestinationRule (subsets stable/canary). Requires the    workload to run in an Istio-injected namespace. The VirtualService timeout/retries and the    DestinationRule trafficPolicy also provide resilience (timeouts, circuit breaking) to callers. |
-| argorollouts.istio.retries | object | `{}` | HTTP retries on the VirtualService (Istio HTTPRetry), e.g.    {attempts: 2, perTryTimeout: "800ms", retryOn: "5xx,reset,connect-failure"} |
-| argorollouts.istio.timeout | string | `""` | HTTP route timeout on the VirtualService (e.g. "2s"). Empty = no timeout. |
-| argorollouts.istio.trafficPolicy | object | `{}` | DestinationRule trafficPolicy for resilience/circuit breaking (connectionPool +    outlierDetection). Argo Rollouts only edits the subsets, leaving this intact. |
 | argorollouts.steps[0].setWeight | int | `20` |  |
 | argorollouts.steps[1].pause.duration | string | `"1m"` |  |
 | argorollouts.steps[2].setWeight | int | `60` |  |
@@ -91,6 +87,11 @@ networkPolicy.internetOnly.ipBlock.except when they are outside the defaults.
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress | bool | `{"enabled":false}` | If true, Creats Ingress DNS name to expose the service publicly |
+| istio | object | `{"enabled":false,"hosts":[],"retries":{},"timeout":"","trafficPolicy":{}}` | Istio traffic management (VirtualService + DestinationRule), INDEPENDENT of Argo Rollouts.    When istio.enabled, the chart renders a VirtualService + DestinationRule for this service,    including resilience (timeouts, retries, circuit breaking) — usable even with argorollouts disabled.    When argorollouts.enabled is ALSO true, the chart makes them canary-aware (stable/canary subsets +    a weighted "primary" route that Argo Rollouts drives) and wires trafficRouting.istio into the    Rollout; otherwise it renders a plain route (100% -> the service) with the same resilience.    Requires the workload to run in an Istio-injected namespace. |
+| istio.hosts | list | `[]` | Hosts for the VirtualService. Empty defaults to ["<fullname>-service"] (in-cluster east-west). |
+| istio.retries | object | `{}` | Istio HTTPRetry, e.g. {attempts: 2, perTryTimeout: "800ms", retryOn: "5xx,reset,connect-failure"} |
+| istio.timeout | string | `""` | HTTP route timeout (e.g. "2s"). Empty = no timeout. |
+| istio.trafficPolicy | object | `{}` | DestinationRule trafficPolicy for resilience / circuit breaking (connectionPool,    outlierDetection, tls, ...). Argo Rollouts only edits the subsets, leaving this intact. |
 | livenessProbe | object | `{}` |  |
 | multiIngress | bool | `{"enabled":false}` | If true, Creats Multible Ingresses DNS name to expose the service publicly |
 | nameOverride | string | `""` |  |

--- a/charts/service/templates/argo-rollouts.yaml
+++ b/charts/service/templates/argo-rollouts.yaml
@@ -62,10 +62,10 @@ spec:
         nginx:
           stableIngress: {{ include "service.fullname" . }}-ingress
       {{- end }}
-      {{- if .Values.argorollouts.istio.enabled }}
+      {{- if .Values.istio.enabled }}
         {{- /* East-west (in-cluster) canary via Istio, composed with the north-south router above.
-               Argo Rollouts weights the VirtualService "primary" route and manages the
-               DestinationRule subsets (canary/stable) in lockstep with the north-south weight. */}}
+               The VirtualService/DestinationRule themselves are defined by the top-level `istio`
+               block (independent of rollouts); here the Rollout just drives their canary weights. */}}
         istio:
           virtualService:
             name: {{ include "service.fullname" . }}

--- a/charts/service/templates/destinationRule.yaml
+++ b/charts/service/templates/destinationRule.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.argorollouts.enabled .Values.argorollouts.istio.enabled }}
-{{- /* Canary-ready DestinationRule for Istio east-west traffic routing.
-       Argo Rollouts updates the subsets with the rollouts-pod-template-hash at each step; the
-       `version` labels below (also set on the pods via canary/stableMetadata) give correct
-       selection before/independent of that. trafficPolicy carries resilience (circuit breaking). */}}
+{{- if .Values.istio.enabled }}
+{{- /* Istio DestinationRule for this service (independent of Argo Rollouts). Carries resilience
+       (trafficPolicy: connectionPool / outlierDetection). When argorollouts is enabled, it also
+       gets canary/stable subsets that Argo Rollouts updates with the pod-template-hash each step;
+       the `version` labels (also set on pods via canary/stableMetadata) give correct selection. */}}
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -11,6 +11,7 @@ metadata:
     {{- include "service.labels" . | nindent 4 }}
 spec:
   host: {{ include "service.fullname" . }}-service
+  {{- if .Values.argorollouts.enabled }}
   subsets:
     - name: stable
       labels:
@@ -18,7 +19,8 @@ spec:
     - name: canary
       labels:
         version: canary
-  {{- with .Values.argorollouts.istio.trafficPolicy }}
+  {{- end }}
+  {{- with .Values.istio.trafficPolicy }}
   trafficPolicy:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/service/templates/virtualService.yaml
+++ b/charts/service/templates/virtualService.yaml
@@ -1,7 +1,8 @@
-{{- if and .Values.argorollouts.enabled .Values.argorollouts.istio.enabled }}
-{{- /* Canary-ready VirtualService for Istio east-west traffic routing. The "primary" route holds
-       two weighted subset destinations (stable/canary); Argo Rollouts sets the weights each step.
-       timeout/retries provide resilience to in-cluster callers (e.g. picker-service -> node-app). */}}
+{{- if .Values.istio.enabled }}
+{{- /* Istio VirtualService for this service (independent of Argo Rollouts). Carries resilience
+       (timeout / retries). When argorollouts is enabled, the "primary" route holds weighted
+       stable/canary subset destinations that Argo Rollouts drives; otherwise it routes 100% to the
+       service. Default host is <fullname>-service (in-cluster east-west); override via istio.hosts. */}}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -10,17 +11,24 @@ metadata:
     {{- include "service.labels" . | nindent 4 }}
 spec:
   hosts:
+    {{- if .Values.istio.hosts }}
+    {{- range .Values.istio.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- else }}
     - {{ include "service.fullname" . }}-service
+    {{- end }}
   http:
     - name: primary
-      {{- with .Values.argorollouts.istio.timeout }}
+      {{- with .Values.istio.timeout }}
       timeout: {{ . }}
       {{- end }}
-      {{- with .Values.argorollouts.istio.retries }}
+      {{- with .Values.istio.retries }}
       retries:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       route:
+        {{- if .Values.argorollouts.enabled }}
         - destination:
             host: {{ include "service.fullname" . }}-service
             subset: stable
@@ -29,6 +37,10 @@ spec:
             host: {{ include "service.fullname" . }}-service
             subset: canary
           weight: 0
+        {{- else }}
+        - destination:
+            host: {{ include "service.fullname" . }}-service
+        {{- end }}
 ---
 {{- else if .Values.virtualService.enabled }}
 apiVersion: networking.istio.io/v1beta1

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -270,22 +270,6 @@ argorollouts:
     #    auto-derive the names from the HTTPRoutes this chart renders (matches the chunking in
     #    httproute.yaml). Set only to override.
     httpRoutes: []
-  # -- Istio EAST-WEST canary. When enabled (with argorollouts.enabled), the Rollout also weights
-  #    in-cluster (service-to-service) traffic via Istio, composed with the north-south router
-  #    (trafficRouting above). The chart renders a canary-ready VirtualService ("primary" route with
-  #    stable/canary weighted subsets) and a DestinationRule (subsets stable/canary). Requires the
-  #    workload to run in an Istio-injected namespace. The VirtualService timeout/retries and the
-  #    DestinationRule trafficPolicy also provide resilience (timeouts, circuit breaking) to callers.
-  istio:
-    enabled: false
-    # -- HTTP route timeout on the VirtualService (e.g. "2s"). Empty = no timeout.
-    timeout: ""
-    # -- HTTP retries on the VirtualService (Istio HTTPRetry), e.g.
-    #    {attempts: 2, perTryTimeout: "800ms", retryOn: "5xx,reset,connect-failure"}
-    retries: {}
-    # -- DestinationRule trafficPolicy for resilience/circuit breaking (connectionPool +
-    #    outlierDetection). Argo Rollouts only edits the subsets, leaving this intact.
-    trafficPolicy: {}
   steps:
   - setWeight: 20
   - pause:
@@ -304,6 +288,25 @@ virtualService:
   enabled: false
   hosts: []
   http: {}
+
+# -- Istio traffic management (VirtualService + DestinationRule), INDEPENDENT of Argo Rollouts.
+#    When istio.enabled, the chart renders a VirtualService + DestinationRule for this service,
+#    including resilience (timeouts, retries, circuit breaking) — usable even with argorollouts disabled.
+#    When argorollouts.enabled is ALSO true, the chart makes them canary-aware (stable/canary subsets +
+#    a weighted "primary" route that Argo Rollouts drives) and wires trafficRouting.istio into the
+#    Rollout; otherwise it renders a plain route (100% -> the service) with the same resilience.
+#    Requires the workload to run in an Istio-injected namespace.
+istio:
+  enabled: false
+  # -- Hosts for the VirtualService. Empty defaults to ["<fullname>-service"] (in-cluster east-west).
+  hosts: []
+  # -- HTTP route timeout (e.g. "2s"). Empty = no timeout.
+  timeout: ""
+  # -- Istio HTTPRetry, e.g. {attempts: 2, perTryTimeout: "800ms", retryOn: "5xx,reset,connect-failure"}
+  retries: {}
+  # -- DestinationRule trafficPolicy for resilience / circuit breaking (connectionPool,
+  #    outlierDetection, tls, ...). Argo Rollouts only edits the subsets, leaving this intact.
+  trafficPolicy: {}
 
 goreplay:
   enabled: false


### PR DESCRIPTION
## Why
In 0.4.0 the Istio VirtualService/DestinationRule + resilience lived under `argorollouts.istio`, so they only rendered when a canary was enabled. But Istio traffic management — especially **timeouts, retries, and circuit breaking** — is independent of Argo Rollouts and should apply to a service **even with rollouts disabled** (e.g. picker→node-app resilience). (Caught before any live service used it — the gitops enablement PR isn't merged.)

## What
- **New top-level `istio` block** owns the VS + DR + resilience: `istio.{enabled, hosts, timeout, retries, trafficPolicy}`. `argorollouts.istio` is removed.
- Templates render VS/DR whenever `istio.enabled`:
  - **rollouts OFF** → plain VirtualService (100% → service) + DestinationRule, both with the resilience config. Mesh routing + circuit breaking without any canary.
  - **rollouts ON** → canary-aware: VS `primary` route with weighted stable/canary subsets + DR subsets; the Rollout's `trafficRouting.istio` drives the weights (composed with the north-south `gatewayAPI`).
- Legacy `virtualService`/`destinationRule` passthrough blocks preserved.
- Bump **0.4.0 → 0.5.0**.

## Verified (`helm template`)
- istio-on / rollouts-off → plain VS (route to service, timeout) + DR (trafficPolicy/outlierDetection), **no subsets, no Rollout**.
- istio-on / rollouts-on → Rollout `trafficRouting` = `gatewayAPI` + `istio`; VS weighted stable/canary; DR subsets. No stale `argorollouts.istio` refs. `helm lint` + `helm-docs` pass.

## Consumers
Configure Istio via the top-level `istio` block. The integration node-app pilot PR will be updated to use it and pin `targetRevision: 0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)