### PR TITLE
feat(service): render HealthCheckPolicy for the canary Service (0.5.1)

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/templates/health-check-policy-canary.yaml
+++ b/charts/service/templates/health-check-policy-canary.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.argorollouts.enabled .Values.gateway.enabled (index .Values "gateway" "healthCheck" "enabled") -}}
+{{- $fullName := include "service.fullname" . -}}
+{{- $canarySvcName := printf "%s-service-canary" $fullName -}}
+# Canary counterpart of the stable HealthCheckPolicy. Without this, the GKE Gateway health-checks the
+# canary backend service with its default probe (HTTP GET / -> 404 for most apps), so canary pods never
+# satisfy the cloud.google.com/load-balancer-neg-ready gate and the Rollout stalls at the first step that
+# needs a second canary pod. Mirrors the stable policy so canary NEG endpoints health-check identically.
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ $fullName }}-canary-healthcheck
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "service.labels" . | nindent 4 }}
+spec:
+  default:
+    checkIntervalSec: {{ .Values.gateway.healthCheck.checkIntervalSec | default 30 }}
+    timeoutSec: {{ .Values.gateway.healthCheck.timeoutSec | default 10 }}
+    healthyThreshold: {{ .Values.gateway.healthCheck.healthyThreshold | default 1 }}
+    unhealthyThreshold: {{ .Values.gateway.healthCheck.unhealthyThreshold | default 5 }}
+    config:
+      type: {{ .Values.gateway.healthCheck.type | default "TCP" }}
+      {{- if eq (.Values.gateway.healthCheck.type | default "TCP") "TCP" }}
+      tcpHealthCheck:
+        port: {{ .Values.gateway.healthCheck.port | default .Values.service.port }}
+      {{- else }}
+      httpHealthCheck:
+        port: {{ .Values.gateway.healthCheck.port | default .Values.service.port }}
+        {{- if .Values.gateway.healthCheck.path }}
+        requestPath: {{ .Values.gateway.healthCheck.path }}
+        {{- end }}
+      {{- end }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $canarySvcName }}
+{{- end }}


### PR DESCRIPTION
## Problem
When `argorollouts` + `gateway` are enabled, the chart creates a `-service-canary` Service but **no HealthCheckPolicy** for it. The GKE Gateway then health-checks the canary backend with its default probe (HTTP `GET /` → 404 for most apps), so canary pods never satisfy the `cloud.google.com/load-balancer-neg-ready` readiness gate and the Rollout **stalls at the first step needing a 2nd canary pod** (observed at 50% in the node-app non-prod pilot).

## Fix
Add `health-check-policy-canary.yaml` mirroring the stable policy (same type/port/thresholds), targeting `<fullname>-service-canary`. Gated on `argorollouts.enabled` + `gateway.healthCheck.enabled` — no change for non-canary/non-gateway services. Chart 0.5.0 → 0.5.1.

Verified with `helm template` against node-app integration values → renders `node-app-canary-healthcheck` (TCP:3030 → node-app-service-canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)