### PR TITLE
feat(oneuptime): add googleChat.directoryImpersonationSubject; bump to 11.0.1-bf.3

### DIFF
--- a/charts/oneuptime/Chart.yaml
+++ b/charts/oneuptime/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Fork pin: upstream OneUptime 11.0.1 chart + Breadfast serviceAccount/googleChat
 # additions. `-bf.N` mirrors the image-tag convention; bump N on every re-sync.
-version: 11.0.1-bf.2
+version: 11.0.1-bf.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/oneuptime/README.md
+++ b/charts/oneuptime/README.md
@@ -1,6 +1,6 @@
 # oneuptime
 
-![Version: 11.0.1-bf.2](https://img.shields.io/badge/Version-11.0.1--bf.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.0.1](https://img.shields.io/badge/AppVersion-11.0.1-informational?style=flat-square)
+![Version: 11.0.1-bf.3](https://img.shields.io/badge/Version-11.0.1--bf.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.0.1](https://img.shields.io/badge/AppVersion-11.0.1-informational?style=flat-square)
 
 The Complete Open-Source Observability Platform
 
@@ -225,6 +225,7 @@ The Complete Open-Source Observability Platform
 | global.clusterDomain | string | `"cluster.local"` |  |
 | global.storageClass | string | `nil` |  |
 | googleChat.customerId | string | `"customers/my_customer"` |  |
+| googleChat.directoryImpersonationSubject | string | `""` |  |
 | googleChat.incidentResponderSpaceName | string | `""` |  |
 | googleChat.incidentUpdatesSpaceName | string | `""` |  |
 | googleChat.onCallCommandId | string | `""` |  |

--- a/charts/oneuptime/templates/_helpers.tpl
+++ b/charts/oneuptime/templates/_helpers.tpl
@@ -70,6 +70,8 @@ app/worker pod specs so a created SA and its consumers always agree on the name.
   value: {{ $.Values.googleChat.incidentResponderSpaceName | default "" | quote }}
 - name: GOOGLE_CHAT_INCIDENT_UPDATES_SPACE_NAME
   value: {{ $.Values.googleChat.incidentUpdatesSpaceName | default "" | quote }}
+- name: GOOGLE_CHAT_DIRECTORY_IMPERSONATION_SUBJECT
+  value: {{ $.Values.googleChat.directoryImpersonationSubject | default "" | quote }}
 
 {{- if $.Values.openTelemetryExporter.endpoint }}
 - name: OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT

--- a/charts/oneuptime/values.schema.json
+++ b/charts/oneuptime/values.schema.json
@@ -2286,6 +2286,12 @@
                         "string",
                         "null"
                     ]
+                },
+                "directoryImpersonationSubject": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "additionalProperties": false

--- a/charts/oneuptime/values.yaml
+++ b/charts/oneuptime/values.yaml
@@ -1020,6 +1020,10 @@ googleChat:
   onCallCommandId: ""
   incidentResponderSpaceName: ""
   incidentUpdatesSpaceName: ""
+  # Workspace user the Chat service account impersonates (domain-wide delegation)
+  # to resolve an on-call engineer's email to their Google Chat mention id.
+  # Empty = directory resolution disabled (/oncall falls back to plain @email).
+  directoryImpersonationSubject: ""
 
 # GitHub Example Configuration
 # gitHubApp:


### PR DESCRIPTION
## What
Mirrors the forked OneUptime chart change for the **/oncall directory-mention** feature: wires a new `GOOGLE_CHAT_DIRECTORY_IMPERSONATION_SUBJECT` env on app + worker via `googleChat.directoryImpersonationSubject`. Empty = dormant (no behavior change).

- `charts/oneuptime/templates/_helpers.tpl` — new env
- `charts/oneuptime/values.yaml` + `values.schema.json` — new value
- `charts/oneuptime/Chart.yaml` — `11.0.1-bf.2` → `11.0.1-bf.3`
- `README.md` — regenerated via helm-docs

## Why
Prod ArgoCD renders via the AVP CMP `helm template --repo https://breadfast.github.io/helm-chart --version <ver>`, so the new env wiring must be in the published chart. Once merged + published, prod's `HELM_CHART_VERSION` bumps to `11.0.1-bf.3`.

Feature is proven on non-prod (2026-07-31): `/oncall` pings a never-interacted engineer via the Admin SDK Directory API (keyless DWD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)