### PR TITLE
Fix service HTTPRoute RequestRedirect rendering

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 home: https://github.com/Breadfast/helm-chart
 sources:

--- a/charts/service/README.md
+++ b/charts/service/README.md
@@ -1,6 +1,6 @@
 # service
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes.
 

--- a/charts/service/templates/httproute.yaml
+++ b/charts/service/templates/httproute.yaml
@@ -164,6 +164,13 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $requestRedirect := false }}
+      {{- range (.filters | default list) }}
+        {{- if eq .type "RequestRedirect" }}
+          {{- $requestRedirect = true }}
+        {{- end }}
+      {{- end }}
+      {{- if not $requestRedirect }}
       {{- $stableName := .serviceName | default $defaultSvcName }}
       {{- $port := .servicePort | default $svcPort }}
       {{- $canaryOnRule := and $gwCanary (eq $stableName $defaultSvcName) }}
@@ -177,6 +184,7 @@ spec:
       - name: {{ $canarySvcName }}
         port: {{ $port }}
         weight: 0
+      {{- end }}
       {{- end }}
     {{ end }}
     {{- end -}}


### PR DESCRIPTION
## Summary
- skip rendering backendRefs for HTTPRoute rules that use a RequestRedirect filter
- keep backendRefs for normal forwarding and URLRewrite rules
- bump service chart to 0.5.2 so the chart release workflow publishes a new package

## Root cause
Gateway API rejects RequestRedirect and backendRefs on the same rule. The service 0.5.1 chart passed filters through but always rendered backendRefs, which made redirect rules invalid.

## Validation
- helm lint charts/service
- git diff --check -- charts/service/templates/httproute.yaml charts/service/Chart.yaml
- helm template react-dashboard charts/service --namespace testing ... | kubectl --context breadfast-non-prod-cluster apply --dry-run=server -f -
- helm template react-dashboard charts/service --namespace integration ... | kubectl --context breadfast-non-prod-cluster apply --dry-run=server -f -