### PR TITLE
feat(oneuptime): add Google Chat group command config

### DIFF
--- a/charts/oneuptime/Chart.yaml
+++ b/charts/oneuptime/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Fork pin: upstream OneUptime 11.0.1 chart + Breadfast serviceAccount/googleChat
 # additions. `-bf.N` mirrors the image-tag convention; bump N on every re-sync.
-version: 11.0.1-bf.3
+version: 11.0.1-bf.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/oneuptime/README.md
+++ b/charts/oneuptime/README.md
@@ -1,6 +1,6 @@
 # oneuptime
 
-![Version: 11.0.1-bf.3](https://img.shields.io/badge/Version-11.0.1--bf.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.0.1](https://img.shields.io/badge/AppVersion-11.0.1-informational?style=flat-square)
+![Version: 11.0.1-bf.4](https://img.shields.io/badge/Version-11.0.1--bf.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.0.1](https://img.shields.io/badge/AppVersion-11.0.1-informational?style=flat-square)
 
 The Complete Open-Source Observability Platform
 
@@ -226,6 +226,7 @@ The Complete Open-Source Observability Platform
 | global.storageClass | string | `nil` |  |
 | googleChat.customerId | string | `"customers/my_customer"` |  |
 | googleChat.directoryImpersonationSubject | string | `""` |  |
+| googleChat.groupCommandId | string | `""` |  |
 | googleChat.incidentResponderSpaceName | string | `""` |  |
 | googleChat.incidentUpdatesSpaceName | string | `""` |  |
 | googleChat.onCallCommandId | string | `""` |  |

--- a/charts/oneuptime/templates/_helpers.tpl
+++ b/charts/oneuptime/templates/_helpers.tpl
@@ -66,6 +66,8 @@ app/worker pod specs so a created SA and its consumers always agree on the name.
   value: {{ $.Values.googleChat.customerId | default "customers/my_customer" | quote }}
 - name: GOOGLE_CHAT_ONCALL_COMMAND_ID
   value: {{ $.Values.googleChat.onCallCommandId | default "" | quote }}
+- name: GOOGLE_CHAT_GROUP_COMMAND_ID
+  value: {{ $.Values.googleChat.groupCommandId | default "" | quote }}
 - name: GOOGLE_CHAT_INCIDENT_RESPONDER_SPACE_NAME
   value: {{ $.Values.googleChat.incidentResponderSpaceName | default "" | quote }}
 - name: GOOGLE_CHAT_INCIDENT_UPDATES_SPACE_NAME

--- a/charts/oneuptime/values.schema.json
+++ b/charts/oneuptime/values.schema.json
@@ -2275,6 +2275,12 @@
                         "null"
                     ]
                 },
+                "groupCommandId": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "incidentResponderSpaceName": {
                     "type": [
                         "string",

--- a/charts/oneuptime/values.yaml
+++ b/charts/oneuptime/values.yaml
@@ -1018,6 +1018,7 @@ googleChat:
   projectNumber: ""
   customerId: "customers/my_customer"
   onCallCommandId: ""
+  groupCommandId: ""
   incidentResponderSpaceName: ""
   incidentUpdatesSpaceName: ""
   # Workspace user the Chat service account impersonates (domain-wide delegation)


### PR DESCRIPTION
Adds production OneUptime chart support for the Google Chat /group command.

Changes:
- Adds googleChat.groupCommandId to values, schema, and README.
- Renders GOOGLE_CHAT_GROUP_COMMAND_ID into OneUptime pods.
- Bumps chart version to 11.0.1-bf.4 for chart-release publication.

Local validation:
- helm lint charts/oneuptime passed.
- helm template with onCallCommandId=2 and groupCommandId=3 confirmed both env vars render.